### PR TITLE
Fix the way border values are read and written

### DIFF
--- a/ooxml/Iron/Util/XSSFCellUtil.cs
+++ b/ooxml/Iron/Util/XSSFCellUtil.cs
@@ -18,8 +18,6 @@ namespace NPOI.XSSF.Util
         public const string BORDER_TOP = "borderTop";
         public const string BOTTOM_BORDER_COLOR = "bottomBorderColor";
         public const string DATA_FORMAT = "dataFormat";
-        public const string DIAGONAL_BORDER_COLOR = "diagonalBorderColor";
-        public const string DIAGONAL_BORDER_LINE_STYLE = "diagonalBorderLineStyle";
         public const string FILL_BACKGROUND_COLOR = "fillBackgroundColor";
         public const string FILL_FOREGROUND_COLOR = "fillForegroundColor";
         public const string FILL_PATTERN = "fillPattern";
@@ -209,11 +207,11 @@ namespace NPOI.XSSF.Util
         {
             Dictionary<string, object> properties = new Dictionary<string, object>();
             Put(properties, ALIGNMENT, style.Alignment);
-            PutShort(properties, BORDER_BOTTOM, (short)style.BorderBottom);
+            Put(properties, BORDER_BOTTOM, style.BorderBottom);
             PutShort(properties, BORDER_DIAGONAL, (short)style.BorderDiagonal);
-            PutShort(properties, BORDER_LEFT, (short)style.BorderLeft);
-            PutShort(properties, BORDER_RIGHT, (short)style.BorderRight);
-            PutShort(properties, BORDER_TOP, (short)style.BorderTop);
+            Put(properties, BORDER_LEFT, style.BorderLeft);
+            Put(properties, BORDER_RIGHT, style.BorderRight);
+            Put(properties, BORDER_TOP, style.BorderTop);
             PutString(properties, BOTTOM_BORDER_COLOR, RgbByteArrayToHexstring(style.BottomBorderXSSFColor?.GetRgbWithTint() ?? style.BottomBorderXSSFColor?.RGB));
             PutShort(properties, DATA_FORMAT, style.DataFormat);
             PutString(properties, FILL_BACKGROUND_COLOR, RgbByteArrayToHexstring(style.FillBackgroundXSSFColor?.GetRgbWithTint() ?? style.FillBackgroundXSSFColor?.RGB));
@@ -248,13 +246,13 @@ namespace NPOI.XSSF.Util
         private static void SetFormatProperties(XSSFCellStyle style, XSSFWorkbook workbook, Dictionary<string, object> properties)
         {
             style.Alignment = GetHorizontalAlignment(properties, ALIGNMENT);
-            style.BorderBottom = (BorderStyle)GetShort(properties, BORDER_BOTTOM);
+            style.BorderBottom = GetBorderStyle(properties, BORDER_BOTTOM);
 
             style.BorderDiagonal = (BorderDiagonal)GetShort(properties, BORDER_DIAGONAL);
 
-            style.BorderLeft = (BorderStyle)GetShort(properties, BORDER_LEFT);
-            style.BorderRight = (BorderStyle)GetShort(properties, BORDER_RIGHT);
-            style.BorderTop = (BorderStyle)GetShort(properties, BORDER_TOP);
+            style.BorderLeft = GetBorderStyle(properties, BORDER_LEFT);
+            style.BorderRight = GetBorderStyle(properties, BORDER_RIGHT);
+            style.BorderTop = GetBorderStyle(properties, BORDER_TOP);
 
             var bottomBorderColor = StringToByteArray(GetString(properties, BOTTOM_BORDER_COLOR));
             if (bottomBorderColor != null)
@@ -327,7 +325,7 @@ namespace NPOI.XSSF.Util
             {
                 style.TopBorderColor = 0;
             }
-            
+
             style.VerticalAlignment = GetVerticalAlignment(properties, VERTICAL_ALIGNMENT);
             style.WrapText = GetBoolean(properties, WRAP_TEXT);
         }
@@ -472,7 +470,7 @@ namespace NPOI.XSSF.Util
             {
                 align = alignment;
             }
-            else if (value is short code) 
+            else if (value is short code)
             {
                 align = (VerticalAlignment)code;
             }


### PR DESCRIPTION
Another example of inconsistent reading and writing of cell style's properties fixed. This also positively impacts performance.