### PR TITLE
Fix an issue with missing ')'

### DIFF
--- a/OpenXmlFormats/Drawing/Chart/Chart.cs
+++ b/OpenXmlFormats/Drawing/Chart/Chart.cs
@@ -8943,7 +8943,7 @@ namespace NPOI.OpenXmlFormats.Dml.Chart
             XmlHelper.WriteAttribute(sw, "formatCode", this.formatCode);
             sw.Write(">");
             if (this.v != null)
-                sw.Write(string.Format("<c:v>{0}</c:v>", this.v.ToString(CultureInfo.InvariantCulture));
+                sw.Write(string.Format("<c:v>{0}</c:v>", this.v.ToString(CultureInfo.InvariantCulture)));
             sw.Write(string.Format("</c:{0}>", nodeName));
         }
 


### PR DESCRIPTION
Fix an issue with missing ')' in CT_NumVal.Write method