### PR TITLE
Fix problems with AutoSize methods

### DIFF
--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -364,7 +364,8 @@ namespace NPOI.SS.Util
 
         private static double GetCellConetntHeight(double actualHeight, int numberOfRowsInMergedRegion)
         {
-            return Math.Max(-1, actualHeight / numberOfRowsInMergedRegion);
+            var correction = 1.1;
+            return Math.Max(-1, actualHeight / numberOfRowsInMergedRegion * correction);
         }
 
         private static string GetCellStringValue(ICell cell)
@@ -544,7 +545,8 @@ namespace NPOI.SS.Util
             // entireWidth accounts for leading spaces which is excluded from bounds.getWidth()
             //double frameWidth = bounds.getX() + bounds.getWidth();
             //width = Math.max(width, ((frameWidth / colspan) / defaultCharWidth) + style.getIndention());
-            width = Math.Max(width, (actualWidth / colspan / defaultCharWidth) + cell.CellStyle.Indention);
+            var correction = 1.1;
+            width = Math.Max(width, (actualWidth / colspan / defaultCharWidth * correction) + cell.CellStyle.Indention);
             return width;
         }
 

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -355,7 +355,7 @@ namespace NPOI.SS.Util
             {
                 if (region.IsInRange(cell.RowIndex, cell.ColumnIndex))
                 {
-                    return 1 + region.LastColumn - region.FirstColumn;
+                    return 1 + region.LastRow - region.FirstRow;
                 }
             }
 


### PR DESCRIPTION
SixLabors.TextMeasurer mesures strings differnetly than System.Common.Drawing did. the corrective coefficients here are not 100% accurate either, but they make sure, that cell contents are not cut off. The coefficient's values were tweaked by testing them on sizable sample of test strings with different fonts, font sizes and string lengths (and hights in case of multy-line strings). Accuracy will vary depending on font size and font itself, but on average acuracy is improved for most cases.