### PR TITLE
Handle the exception when system has no fonts

### DIFF
--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -683,14 +683,21 @@ namespace NPOI.SS.Util
         //    if (font.IsItalic) str.AddAttribute(TextAttribute.POSTURE, TextAttribute.POSTURE_OBLIQUE, startIdx, endIdx);
         //    TODO-Fonts: not supported: if (font.Underline == (byte)FontUnderlineType.SINGLE) str.AddAttribute(TextAttribute.UNDERLINE, TextAttribute.UNDERLINE_ON, startIdx, endIdx);           
         //}
-
+        
         /// <summary>
         /// Convert HSSFFont to Font.
         /// </summary>
         /// <param name="font1">The font.</param>
         /// <returns></returns>
+        /// <exception cref="FontException">Will throw this if no font are 
+        /// found by SixLabors in the current environment.</exception>
         internal static Font IFont2Font(IFont font1)
         {
+            if (SystemFonts.Families == null || SystemFonts.Families.Count() == 0)
+            {
+                throw new FontException("No fonts found installed on the machine.");
+            }
+
             FontStyle style = FontStyle.Regular;
             if (font1.IsBold)
             {


### PR DESCRIPTION
On linux (specifically in latest docker ubuntu images) if there are no font's installed in the operating system the method SheetUtil.IFont2Font will throw an unifotmative exception stating that "Sequence contains no elements" Now it will throw an exception that will be more informative.