### PR TITLE
Fix closing <br> tag bug

### DIFF
--- a/ooxml/XSSF/UserModel/XSSFVMLDrawing.cs
+++ b/ooxml/XSSF/UserModel/XSSFVMLDrawing.cs
@@ -116,7 +116,7 @@ namespace NPOI.XSSF.UserModel
             //Stream vmlsm = new EvilUnclosedBRFixingInputStream(is1); --TODO:: add later
             
              doc.LoadXml(
-                  data.Replace("<br>","")//.Replace("</br>", "")
+                  data.Replace("<br>","").Replace("</br>", "")
             );
 
              XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.NameTable);

--- a/ooxml/XSSF/UserModel/XSSFVMLDrawing.cs
+++ b/ooxml/XSSF/UserModel/XSSFVMLDrawing.cs
@@ -116,7 +116,7 @@ namespace NPOI.XSSF.UserModel
             //Stream vmlsm = new EvilUnclosedBRFixingInputStream(is1); --TODO:: add later
             
              doc.LoadXml(
-                  data.Replace("<br>","")
+                  data.Replace("<br>","")//.Replace("</br>", "")
             );
 
              XmlNamespaceManager nsmgr = new XmlNamespaceManager(doc.NameTable);

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFVMLDrawing.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFVMLDrawing.cs
@@ -128,6 +128,17 @@ namespace TestCases.XSSF.UserModel
             Assert.AreSame(sh_a1, newVml.FindCommentShape(0, 1));
         }
         [Test]
+        public void TestRead()
+        {
+            XSSFVMLDrawing vml = new XSSFVMLDrawing();
+
+            // Act
+            TestDelegate testDelegate = () => vml.Read(POIDataSamples.GetSpreadSheetInstance().OpenResourceAsStream("vmlDrawing1.vml"));
+
+            // Assert
+            Assert.DoesNotThrow(testDelegate);
+        }
+        [Test]
         public void TestRemoveCommentShape()
         {
             XSSFVMLDrawing vml = new XSSFVMLDrawing();

--- a/testcases/test-data/spreadsheet/vmlDrawing1.vml
+++ b/testcases/test-data/spreadsheet/vmlDrawing1.vml
@@ -13,6 +13,9 @@
     <v:path o:connecttype="none"/>
     <v:textbox style="mso-direction-alt:auto">
       <div style="text-align:left"/>
+      <div style='text-align:center'>
+        <b>Some Text<br></br></b>
+      </div>
     </v:textbox>
     <x:ClientData ObjectType="Note">
       <x:MoveWithCells/>


### PR DESCRIPTION
When vml contained <br> and </br> the XSSFVMLDrawing.Read() would remove <br> leaving </br> hanging, which would cause an exception being thrown.