### PR TITLE
XL148 - fix CT_FormulaCell writer

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet.cs
@@ -2701,7 +2701,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "r1", this.r1);
             XmlHelper.WriteAttribute(sw, "r2", this.r2);
             XmlHelper.WriteAttribute(sw, "ca", this.ca, false);
-            if(this.si!=0)
+            if(this.t == ST_CellFormulaType.shared || this.si!=0)
                 XmlHelper.WriteAttribute(sw, "si", this.si, true);
             XmlHelper.WriteAttribute(sw, "bx", this.bx, false);
             if (!string.IsNullOrEmpty(this.valueField))


### PR DESCRIPTION
CT_CellFormula: ensure the `siField` is written into `fField`'s attributes on `Write` even when it has a default value for cases when the type of the formula is Shared formula.