### PR TITLE
For January 2025 Release

### DIFF
--- a/main/NPOI.Multitarget.csproj
+++ b/main/NPOI.Multitarget.csproj
@@ -29,7 +29,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Configuration.ConfigurationManager" Version="[6.0.1]" />
+		<PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.2" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
I have updated System.Configuration.ConfigurationManager to 6.0.2.
This is because IronSoftware.Internal uses version 6.0.2

Severity Code Description Project File Line Suppression State Details
Error NU1107 Version conflict detected for System.Configuration.ConfigurationManager. Install/reference System.Configuration.ConfigurationManager 6.0.2 directly to project IronXL to resolve this issue.
IronXL -> IronSoftware.Internals 2024.11.4 -> System.Configuration.ConfigurationManager (>= 6.0.2)
IronXL -> NPOI.OpenXmlFormats.Multitarget -> NPOI.Multitarget -> System.Configuration.ConfigurationManager (= 6.0.1). IronXL C:\Users\chakn\Documents\GitHub\IronXL\IronXL\IronXL.csproj 1