### PR TITLE
XL 65 - Missing or conflict value in header break Excel file

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
@@ -838,7 +838,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "id", this.id);
             XmlHelper.WriteAttribute(sw, "uniqueName", this.uniqueName);
-            XmlHelper.WriteAttribute(sw, "name", this.name);
+            XmlHelper.WriteAttribute(sw, "name", XmlHelper.ExcelEncodeString(this.name));
             XmlHelper.WriteAttribute(sw, "totalsRowFunction", this.totalsRowFunction.ToString());
             XmlHelper.WriteAttribute(sw, "totalsRowLabel", this.totalsRowLabel);
             XmlHelper.WriteAttribute(sw, "queryTableFieldId", this.queryTableFieldId);

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
@@ -39,7 +39,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private ST_TableType tableTypeField;
 
-        private uint headerRowCountField;
+        private bool headerRowCountField;
 
         private bool insertRowField;
 
@@ -93,7 +93,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             //this.sortStateField = new CT_SortState();
             //this.autoFilterField = new CT_AutoFilter();
             this.tableTypeField = ST_TableType.worksheet;
-            this.headerRowCountField = ((uint)(1));
+            this.headerRowCountField = true;
             this.insertRowField = false;
             this.insertRowShiftField = false;
             this.totalsRowCountField = ((uint)(0));
@@ -114,7 +114,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node.Attributes["tableType"] != null)
                 ctObj.tableType = (ST_TableType)Enum.Parse(typeof(ST_TableType), node.Attributes["tableType"].Value);
             if (node.Attributes["headerRowCount"] != null)
-                ctObj.headerRowCount = XmlHelper.ReadUInt(node.Attributes["headerRowCount"]);
+                ctObj.headerRowCount = XmlHelper.ReadBool(node.Attributes["headerRowCount"]);
             if (node.Attributes["insertRow"] != null)
                 ctObj.insertRow = XmlHelper.ReadBool(node.Attributes["insertRow"]);
             if (node.Attributes["insertRowShift"] != null)
@@ -336,8 +336,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
         [XmlAttribute]
-        [DefaultValue(typeof(uint), "1")]
-        public uint headerRowCount
+        [DefaultValue(true)]
+        public bool headerRowCount
         {
             get
             {

--- a/ooxml/XSSF/UserModel/XSSFTable.cs
+++ b/ooxml/XSSF/UserModel/XSSFTable.cs
@@ -476,11 +476,11 @@ namespace NPOI.XSSF.UserModel
         /// 0 for no header rows, 1 for table headers shown.
         /// Values > 1 might be used by Excel for pivot tables?
         /// </summary>
-        public int HeaderRowCount
+        public bool HeaderRowCount
         {
             get 
             {
-                return (int)ctTable.headerRowCount;
+                return ctTable.headerRowCount;
             }
         }
         /**

--- a/openxml4Net/Util/XmlHelper.cs
+++ b/openxml4Net/Util/XmlHelper.cs
@@ -260,12 +260,18 @@ namespace NPOI.OpenXml4Net.Util
             //}
             for (int i = 0; i < t.Length; i++)
             {
-                if (t[i] <= 0x1f && t[i] != '\t' && t[i] != '\n' && t[i] != '\r') //Not Tab, CR or LF
+                if (t[i] == '\t')
                 {
-                    //[0x00-0x0a]-[\r\n\t]
-                    //poi replace those chars with ?
+                    sw.Write("_x0009_");
+                }
+                else if (t[i] == '\r' || t[i] == '\n')
+                {
+                    sw.Write("_x000A_");
+                }
+                else if (t[i] <= 0x1f)
+                {
+                    // Excel and poi replace those chars with ?
                     sw.Write('?');
-                    //sw.Write("_x00{0}_", (t[i] < 0xa ? "0" : "") + ((int)t[i]).ToString("X"));
                 }
                 else if (t[i] == '\uFFFE')
                 {


### PR DESCRIPTION
This is the fix for XL 65 on NPOI side.
I have fixed two things here.
- headerRowCount is the attribute to either display the header or not. uint data type does not work on this case. I have changed it to bool.
- handle tab, newline, carriage return in a better way. The old implementation just skip encoding for these three. However, it works better when converting it to four-digit hexadecimal code.

PR on IronXL: https://github.com/iron-software/IronXL/pull/249