### PR TITLE
XL-95: AutoSizeRow method does not account for WrapText property (NPOI repo)

### DIFF
--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
@@ -838,7 +838,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             sw.Write(string.Format("<{0}", nodeName));
             XmlHelper.WriteAttribute(sw, "id", this.id);
             XmlHelper.WriteAttribute(sw, "uniqueName", this.uniqueName);
-            XmlHelper.WriteAttribute(sw, "name", this.name);
+            XmlHelper.WriteAttribute(sw, "name", XmlHelper.ExcelEncodeString(this.name));
             XmlHelper.WriteAttribute(sw, "totalsRowFunction", this.totalsRowFunction.ToString());
             XmlHelper.WriteAttribute(sw, "totalsRowLabel", this.totalsRowLabel);
             XmlHelper.WriteAttribute(sw, "queryTableFieldId", this.queryTableFieldId);

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Table.cs
@@ -39,7 +39,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private ST_TableType tableTypeField;
 
-        private uint headerRowCountField;
+        private bool headerRowCountField;
 
         private bool insertRowField;
 
@@ -93,7 +93,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             //this.sortStateField = new CT_SortState();
             //this.autoFilterField = new CT_AutoFilter();
             this.tableTypeField = ST_TableType.worksheet;
-            this.headerRowCountField = ((uint)(1));
+            this.headerRowCountField = true;
             this.insertRowField = false;
             this.insertRowShiftField = false;
             this.totalsRowCountField = ((uint)(0));
@@ -114,7 +114,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             if (node.Attributes["tableType"] != null)
                 ctObj.tableType = (ST_TableType)Enum.Parse(typeof(ST_TableType), node.Attributes["tableType"].Value);
             if (node.Attributes["headerRowCount"] != null)
-                ctObj.headerRowCount = XmlHelper.ReadUInt(node.Attributes["headerRowCount"]);
+                ctObj.headerRowCount = XmlHelper.ReadBool(node.Attributes["headerRowCount"]);
             if (node.Attributes["insertRow"] != null)
                 ctObj.insertRow = XmlHelper.ReadBool(node.Attributes["insertRow"]);
             if (node.Attributes["insertRowShift"] != null)
@@ -336,8 +336,8 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             }
         }
         [XmlAttribute]
-        [DefaultValue(typeof(uint), "1")]
-        public uint headerRowCount
+        [DefaultValue(true)]
+        public bool headerRowCount
         {
             get
             {

--- a/main/HSSF/Record/DefaultRowHeightRecord.cs
+++ b/main/HSSF/Record/DefaultRowHeightRecord.cs
@@ -40,7 +40,7 @@ namespace NPOI.HSSF.Record
         public const short sid = 0x225;
         private short field_1_option_flags;
 
-        // Default xls height row here, based on the new Excel format default height
+        // Default xls height row here, based on the old Excel format default height
         private short field_2_row_height;
         /**
      * The default row height for empty rows is 255 twips (255 / 20 == 12.75 points)

--- a/main/HSSF/Record/DefaultRowHeightRecord.cs
+++ b/main/HSSF/Record/DefaultRowHeightRecord.cs
@@ -39,6 +39,8 @@ namespace NPOI.HSSF.Record
     {
         public const short sid = 0x225;
         private short field_1_option_flags;
+
+        // Default xls height row here, based on the new Excel format default height
         private short field_2_row_height;
         /**
      * The default row height for empty rows is 255 twips (255 / 20 == 12.75 points)

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -326,12 +326,132 @@ namespace NPOI.SS.Util
 
         public static double GetCellHeight(ICell cell, bool useMergedCells)
         {
-            ICell cellToMeasure = useMergedCells ? GetFirstCellFromMergedRegion(cell) : cell;
+            if (cell == null)
+                return -1;
 
-            double stringHeight = GetActualHeight(cellToMeasure);
-            int numberOfRowsInMergedRegion = useMergedCells ? GetNumberOfRowsInMergedRegion(cellToMeasure) : 1;
+            // 1. Check if the cell is part of a merged region
+            if (useMergedCells && cell.IsMergedCell)
+                return cell.Sheet.DefaultRowHeightInPoints;
 
-            return GetCellConetntHeight(stringHeight, numberOfRowsInMergedRegion);
+            var style = cell.CellStyle;
+            if (style == null)
+                return GetActualHeight(cell); // fallback to simple actual height
+
+            bool isWrap = style.WrapText;
+            //bool isRotated = style.Rotation != 0;
+            string stringValue = GetCellStringValue(cell);
+            Font windowsFont = GetWindowsFont(cell);
+
+            // To-Do: case WrapText with Rotation
+            // Case 1: Rotation + WrapText (special rule: only shrink, not expand)
+            //if (isWrap && isRotated)
+            //{
+            //    double contentHeight = GetRotatedContentHeight(cell, stringValue, windowsFont);
+            //    double currentRowHeight = cell.Row.HeightInPoints;
+
+            //    // Only shrink if content is smaller than current row height
+            //    return contentHeight < currentRowHeight ? contentHeight : currentRowHeight;
+            //}
+
+            // Case 2: WrapText only (normal grow/shrink behavior)
+            if (isWrap)
+            {
+                return GetWrapCellHeight(cell, useMergedCells);
+            }
+
+            // To-Do: case WrapText with Rotation
+            // Case 3: Rotation only (auto-size enabled)
+            //if (isRotated)
+            //{
+            //    return GetRotatedContentHeight(cell, stringValue, windowsFont);
+            //}
+
+            // Case 4: Normal text, auto-size
+            return GetActualHeight(cell);
+        }
+
+        /// <summary>
+        /// Calculates the required height of a cell with WrapText enabled.
+        /// </summary>
+        private static double GetWrapCellHeight(ICell cell, bool useMergedCells)
+        {
+            if (cell == null || cell.Row == null)
+            {
+                return cell.Sheet.DefaultRowHeightInPoints; // return default row height 
+            }
+
+            ISheet sheet = cell.Sheet;
+
+            // 1. Get all the necessary info
+            string stringValue = GetCellStringValue(cell);
+            if (string.IsNullOrEmpty(stringValue))
+            {
+                return cell.Sheet.DefaultRowHeightInPoints; // return default row height 
+            }
+
+            Font font = GetWindowsFont(cell);
+
+            // 2. Calculate the available width for the text in pixels
+            double availableWidthPixels = GetColumnWidthInPixels(sheet, cell.ColumnIndex, cell);
+            //availableWidthPixels = 96;
+
+            // Subtract a small amount for cell padding
+            availableWidthPixels -= 5;
+            if (availableWidthPixels <= 0)
+            {
+                return GetContentHeight(stringValue, font); // Not enough space to wrap
+            }
+
+            // 3. Measure the text height with wrapping
+            string[] lines = stringValue.Split('\n');
+            double totalHeightPixels = 0;
+
+            foreach (string line in lines)
+            {
+                if (string.IsNullOrEmpty(line))
+                {
+                    // Handle empty lines from manual breaks (\n\n)
+                    totalHeightPixels += font.Size;
+                    continue;
+                }
+
+                // Use SixLabors.Fonts to measure the string with a wrapping length.
+                var textOptions = new TextOptions(font) { WrappingLength = (float)availableWidthPixels, Dpi = dpi };
+                FontRectangle measuredBounds = TextMeasurer.MeasureAdvance(line, textOptions);
+
+                totalHeightPixels += Math.Round(measuredBounds.Height, 0, MidpointRounding.ToEven);
+            }
+
+            return totalHeightPixels;
+        }
+
+        /// <summary>
+        /// Finds the CellRangeAddress for a given cell, if it's part of a merged region.
+        /// </summary>
+        public static CellRangeAddress GetMergedRegionForCell(ICell cell)
+        {
+            if (cell == null || !cell.IsMergedCell)
+                return null;
+            foreach (var region in cell.Sheet.MergedRegions)
+            {
+                if (region.IsInRange(cell.RowIndex, cell.ColumnIndex))
+                {
+                    return region;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Converts Excel's column width (units of 1/256th of a character width) to pixels.
+        /// </summary>
+        private static double GetColumnWidthInPixels(ISheet sheet, int columnIndex, ICell cell)
+        {
+            double widthInUnits = sheet.GetColumnWidth(columnIndex);
+            int cellFontCharWidth = GetCellFontCharWidth(cell);
+
+            // This formula is a standard approximation
+            return (double)widthInUnits / 256 * cellFontCharWidth;
         }
 
         private static ICell GetFirstCellFromMergedRegion(ICell cell)
@@ -373,9 +493,9 @@ namespace NPOI.SS.Util
             return 1;
         }
 
-        private static double GetCellConetntHeight(double actualHeight, int numberOfRowsInMergedRegion)
+        private static double GetCellContentHeight(double actualHeight, int numberOfRowsInMergedRegion)
         {
-            return Math.Max(-1, actualHeight / numberOfRowsInMergedRegion);
+            return numberOfRowsInMergedRegion <= 1 ? actualHeight : Math.Max(-1, actualHeight / numberOfRowsInMergedRegion);
         }
 
         private static string GetCellStringValue(ICell cell)
@@ -430,6 +550,34 @@ namespace NPOI.SS.Util
             var x2 = Math.Abs(measureResult.Width * Math.Sin(angle));
 
             return Math.Round(x1 + x2, 0, MidpointRounding.ToEven);
+
+            // To-Do: fix calculation of text rotation with height
+            //if (cell == null || cell.CellStyle == null || string.IsNullOrEmpty(stringValue))
+            //    return 0;
+
+            //// Convert degrees to radians
+            //double angleRad = cell.CellStyle.Rotation * Math.PI / 180.0;
+
+            //// Measure unrotated text size
+            //var textSize = TextMeasurer.MeasureAdvance(
+            //    stringValue,
+            //    new TextOptions(windowsFont)
+            //    {
+            //        Dpi = dpi
+            //    }
+            //);
+
+            //// Get the column width in pixels or points (depends on your library; adjust accordingly)
+            //double columnWidthInPixels = GetColumnWidthInPixels(cell.Sheet, cell.ColumnIndex, cell);
+
+            //// Optional: Clamp text width to cell width if needed
+            //var measuredTextWidth = Math.Min(textSize.Width, columnWidthInPixels);
+
+            //// Calculate rotated bounding box height
+            //double rotatedHeight = Math.Abs(textSize.Height * Math.Cos(angleRad)) + Math.Abs(measuredTextWidth * Math.Sin(angleRad));
+            ////double rotatedHeight = (Math.Abs(textSize.Height * Math.Cos(angleRad)) + Math.Abs(measuredTextWidth * Math.Sin(angleRad))) * 1.07 + 1.5;
+            //return Math.Round(rotatedHeight, 0, MidpointRounding.ToEven);
+
         }
 
         private static double GetContentHeight(string stringValue, Font windowsFont)
@@ -589,7 +737,8 @@ namespace NPOI.SS.Util
             int defaultCharWidth = GetDefaultCharWidth(sheet.Workbook);
 
             // No need to explore the whole sheet: explore only the first maxRows lines
-            if (maxRows > 0 && lastRow - firstRow > maxRows) lastRow = firstRow + maxRows;
+            if (maxRows > 0 && lastRow - firstRow > maxRows)
+                lastRow = firstRow + maxRows;
 
             double width = -1;
             for (int rowIdx = firstRow; rowIdx <= lastRow; ++rowIdx)
@@ -616,6 +765,39 @@ namespace NPOI.SS.Util
             Font font = IFont2Font(defaultFont);
 
             return (int)Math.Ceiling(TextMeasurer.MeasureSize(new string(defaultChar, 1), new TextOptions(font) { Dpi = dpi }).Width);
+        }
+
+        /// <summary>
+        /// Gets the width of a standard character ('0') using the specific font and style of the given cell.
+        /// This provides a font-specific benchmark for layout calculations like column width or text wrapping.
+        /// </summary>
+        public static int GetCellFontCharWidth(ICell cell)
+        {
+            // 1. Guard clause for null cells.
+            if (cell == null)
+            {
+                return 0;
+            }
+
+            // 2. Get the workbook and the cell's specific style.
+            IWorkbook wb = cell.Sheet.Workbook;
+            ICellStyle style = cell.CellStyle;
+
+            // 3. Get the IFont object from the style's font index.
+            // Every style points to a font in the workbook's font table.
+            IFont npoiFont = wb.GetFontAt(style.FontIndex);
+
+            // 4. Convert the NPOI IFont to a SixLabors.Fonts.Font object
+            // using the existing helper method.
+            Font sixLaborsFont = IFont2Font(npoiFont);
+
+            // 5. Measure the width of the single 'defaultChar' ('0') which is defined
+            // at the class level. We use MeasureAdvance as it's efficient for single-line width.
+            var textOptions = new TextOptions(sixLaborsFont) { Dpi = dpi };
+            FontRectangle size = TextMeasurer.MeasureAdvance(defaultChar.ToString(), textOptions);
+
+            // 6. Return the calculated width.
+            return (int)Math.Ceiling(size.Width);
         }
 
         /**

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -51,6 +51,7 @@ namespace NPOI.XSSF.UserModel
     {
         private static readonly POILogger logger = POILogFactory.GetLogger(typeof(XSSFSheet));
 
+        // Default xls height row here, based on the new Excel format default height
         private static readonly double DEFAULT_ROW_HEIGHT = 15.0;
         private static readonly double DEFAULT_MARGIN_HEADER = 0.3;
         private static readonly double DEFAULT_MARGIN_FOOTER = 0.3;

--- a/ooxml/XSSF/UserModel/XSSFTable.cs
+++ b/ooxml/XSSF/UserModel/XSSFTable.cs
@@ -476,11 +476,11 @@ namespace NPOI.XSSF.UserModel
         /// 0 for no header rows, 1 for table headers shown.
         /// Values > 1 might be used by Excel for pivot tables?
         /// </summary>
-        public int HeaderRowCount
+        public bool HeaderRowCount
         {
             get 
             {
-                return (int)ctTable.headerRowCount;
+                return ctTable.headerRowCount;
             }
         }
         /**

--- a/openxml4Net/Util/XmlHelper.cs
+++ b/openxml4Net/Util/XmlHelper.cs
@@ -260,12 +260,18 @@ namespace NPOI.OpenXml4Net.Util
             //}
             for (int i = 0; i < t.Length; i++)
             {
-                if (t[i] <= 0x1f && t[i] != '\t' && t[i] != '\n' && t[i] != '\r') //Not Tab, CR or LF
+                if (t[i] == '\t')
                 {
-                    //[0x00-0x0a]-[\r\n\t]
-                    //poi replace those chars with ?
+                    sw.Write("_x0009_");
+                }
+                else if (t[i] == '\r' || t[i] == '\n')
+                {
+                    sw.Write("_x000A_");
+                }
+                else if (t[i] <= 0x1f)
+                {
+                    // Excel and poi replace those chars with ?
                     sw.Write('?');
-                    //sw.Write("_x00{0}_", (t[i] < 0xa ? "0" : "") + ((int)t[i]).ToString("X"));
                 }
                 else if (t[i] == '\uFFFE')
                 {

--- a/testcases/ooxml/XSSF/UserModel/TestXSSFTable.cs
+++ b/testcases/ooxml/XSSF/UserModel/TestXSSFTable.cs
@@ -17,15 +17,15 @@
 
 namespace TestCases.XSSF.UserModel
 {
-    using System;
-    using System.Collections.Generic;
     using NPOI.OpenXmlFormats.Spreadsheet;
     using NPOI.SS.UserModel;
     using NPOI.SS.Util;
     using NPOI.XSSF;
     using NPOI.XSSF.UserModel;
     using NUnit.Framework;
-
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
 
     [TestFixture]
     public class TestXSSFTable
@@ -220,6 +220,42 @@ namespace TestCases.XSSF.UserModel
             Assert.AreEqual("Display name", table.DisplayName);
             Assert.AreEqual("\\_Prime.1", table.Name); // name and display name are different
             wb.Close();
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void SetAndGetHeaderRowCount(bool headerRowCountValue)
+        {
+            XSSFWorkbook wb = new XSSFWorkbook();
+            XSSFSheet sh = wb.CreateSheet() as XSSFSheet;
+
+            XSSFRow row = sh.CreateRow(0) as XSSFRow;
+            row.CreateCell(0).SetCellValue("Col1");
+            row.CreateCell(1).SetCellValue("Col2");
+
+            row = sh.CreateRow(1) as XSSFRow;
+            row.CreateCell(0).SetCellValue("Value1");
+            row.CreateCell(1).SetCellValue("Value2");
+
+            XSSFTable table = sh.CreateTable();
+            CT_Table ctTable = table.GetCTTable();
+            ctTable.@ref = "A1:B2";
+            ctTable.id = 1;
+            ctTable.name = "table1";
+
+            ctTable.headerRowCount = headerRowCountValue;
+
+            MemoryStream memoryStream = new MemoryStream();
+            wb.Write(memoryStream, leaveOpen: true);
+
+            memoryStream.Position = 0;
+
+            wb = new XSSFWorkbook(memoryStream);
+            table = wb.GetTable("table1");
+            ctTable = table.GetCTTable();
+
+            Assert.AreEqual(headerRowCountValue, ctTable.headerRowCount);
+            memoryStream.Dispose();
         }
 
         [Test]


### PR DESCRIPTION
Added
- Comments explaining the default row height for both `.xls` and `.xlsx` formats.
- A new method to calculate cell width based on the **cell's style** instead of the sheet's default.
- A new method to handle `WrapText` alignment correctly when used with merged cells.
Updated
 - Fixed typos in method names.

Reference: [IronXL PR #252](https://github.com/iron-software/IronXL/pull/252)