### PR TITLE
IsDVTPriorRecord updated for RowRecordsAggregate

### DIFF
--- a/main/HSSF/Model/RecordOrderer.cs
+++ b/main/HSSF/Model/RecordOrderer.cs
@@ -306,7 +306,7 @@ namespace NPOI.HSSF.Model
 
         private static bool IsDVTPriorRecord(RecordBase rb)
         {
-            if (rb is MergedCellsTable || rb is ConditionalFormattingTable)
+            if (rb is MergedCellsTable || rb is ConditionalFormattingTable || rb is RowRecordsAggregate)
             {
                 return true;
             }


### PR DESCRIPTION
When attempting to load certain .xls files using IronXL.WorkBook.LoadExcel(), an unhandled **InvalidCastException** is thrown from NPOI. This occurs during the internal parsing of Data Validation records, where a **RowRecordsAggregate** is incorrectly cast to a **Record** type.

**IsDVTPriorRecord** is updated with `rb is RowRecordsAggregate`