### PR TITLE
XL-257: Reduce memory consumption for large XLSX loading

### DIFF
--- a/OpenXmlFormats/Spreadsheet/SharedString/CT_Rst.cs
+++ b/OpenXmlFormats/Spreadsheet/SharedString/CT_Rst.cs
@@ -244,16 +244,24 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         public static CT_Rst Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
             CT_Rst ctObj = new CT_Rst();
-            ctObj.r = new List<CT_RElt>();
-            ctObj.rPh = new List<CT_PhoneticRun>();
+            // Lazy-initialize lists only when elements are found.
+            // Most shared string entries only have <t> text with no rich text runs
+            // or phonetic runs, so avoiding empty List allocations saves significant
+            // memory when there are many unique strings (40 bytes per empty List<T>).
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "phoneticPr")
                     ctObj.phoneticPr = CT_PhoneticPr.Parse(childNode, namespaceManager);
                 else if (childNode.LocalName == "r")
+                {
+                    if (ctObj.r == null) ctObj.r = new List<CT_RElt>();
                     ctObj.r.Add(CT_RElt.Parse(childNode, namespaceManager));
+                }
                 else if (childNode.LocalName == "rPh")
+                {
+                    if (ctObj.rPh == null) ctObj.rPh = new List<CT_PhoneticRun>();
                     ctObj.rPh.Add(CT_PhoneticRun.Parse(childNode, namespaceManager));
+                }
                 else if (childNode.LocalName == "t")
                     ctObj.t = childNode.InnerText.Replace("\r", "");
             }
@@ -262,7 +270,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         public int SizeOfRArray()
         {
-            return r.Count;
+            return (null == rField) ? 0 : r.Count;
         }
     }
 }

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Cell.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Cell.cs
@@ -25,15 +25,25 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private string rField = null;
 
-        private uint? sField = null;
+        // Memory optimization: replaced nullable fields (uint?, ST_CellType?, bool?)
+        // with plain value-type fields. Each Nullable<T> costs 8-12 bytes due to the
+        // hasValue flag + alignment padding. For 150K cells, this saves ~5 MB.
+        //
+        // Behavioral equivalence:
+        //   - IsSetS() checked (sField != null && sField != 0)  →  now checks (sField != 0)
+        //     Both are equivalent: unsetS() sets to 0, Parse sets 0 when attribute absent.
+        //   - IsSetT() checked (tField != ST_CellType.n)  →  unchanged logic
+        //   - The s/cm/vm/ph property getters returned default when null; now return field directly.
+        //   - Write() uses value-based checks (== 0, == false), not null checks — unchanged.
+        private uint sField;
 
-        private ST_CellType? tField = null;
+        private ST_CellType tField = ST_CellType.n;
 
-        private uint? cmField = null;
+        private uint cmField;
 
-        private uint? vmField = null;
+        private uint vmField;
 
-        private bool? phField = null;
+        private bool phField;
 
         public static CT_Cell Parse(XmlNode node, XmlNamespaceManager namespaceManager)
         {
@@ -100,17 +110,6 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
 
 
-        //public CT_Cell()
-        //{
-        //    this.extLstField = new CT_ExtensionList();
-        //    //this.isField = new CT_Rst();
-        //    //this.fField = new CT_CellFormula();
-        //    this.sField = (uint)(0);
-        //    this.tField = ST_CellType.n;
-        //    this.cmField = ((uint)(0));
-        //    this.vmField = ((uint)(0));
-        //    this.phField = false;
-        //}
         public void Set(CT_Cell cell)
         {
             fField = cell.fField;
@@ -130,7 +129,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public bool IsSetS()
         {
-            return sField != null && sField != 0;
+            return sField != 0;
         }
         public bool IsSetF()
         {
@@ -242,7 +241,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == sField ? 0 : (uint)this.sField;
+                return this.sField;
             }
             set
             {
@@ -255,7 +254,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == tField ? ST_CellType.n : (ST_CellType)this.tField;
+                return this.tField;
             }
             set
             {
@@ -268,7 +267,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == cmField ? 0 : (uint)this.cmField;
+                return this.cmField;
             }
             set
             {
@@ -281,7 +280,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == vmField ? 0 : (uint)this.vmField;
+                return this.vmField;
             }
             set
             {
@@ -294,7 +293,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return null == phField ? false : (bool)this.phField;
+                return this.phField;
             }
             set
             {

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
@@ -59,8 +59,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 return null;
             CT_Row ctObj = new CT_Row();
             ctObj.r = XmlHelper.ReadUInt(node.Attributes["r"]);
-            string rawSpans = XmlHelper.ReadString(node.Attributes["spans"]);
-            ctObj.spans = rawSpans != null ? string.Intern(rawSpans) : null;
+            ctObj.spans = XmlHelper.ReadString(node.Attributes["spans"]);
             ctObj.s = XmlHelper.ReadUInt(node.Attributes["s"]);
             ctObj.customFormat = XmlHelper.ReadBool(node.Attributes["customFormat"]);
             ctObj.dyDescentField = XmlHelper.ReadDouble(node.Attributes["x14ac:dyDescent"]);

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_Row.cs
@@ -27,23 +27,28 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
 
         private uint sField;
 
-        private bool customFormatField;
+        // Memory optimization: pack 7 boolean fields into a single byte using flags.
+        // Each individual bool field consumes 1 byte + alignment padding = 4 bytes
+        // in practice on 64-bit. 7 bools = 28 bytes. A single flags byte = 1 byte.
+        // Savings: ~24 bytes per row × 10K rows = ~240KB.
+        [Flags]
+        private enum RowFlags : byte
+        {
+            None = 0,
+            CustomFormat = 1,
+            Hidden = 2,
+            CustomHeight = 4,
+            Collapsed = 8,
+            ThickTop = 16,
+            ThickBot = 32,
+            Ph = 64
+        }
+        private RowFlags _flags;
 
-        private double htField=-1;
-
-        private bool hiddenField;
-
-        private bool customHeightField;
+        private double htField = -1;
 
         private byte outlineLevelField;
 
-        private bool collapsedField;
-
-        private bool thickTopField;
-
-        private bool thickBotField;
-
-        private bool phField;
         private double dyDescentField; //x14ac:dyDescent
 
         private int lastCellField = -1;
@@ -54,11 +59,12 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 return null;
             CT_Row ctObj = new CT_Row();
             ctObj.r = XmlHelper.ReadUInt(node.Attributes["r"]);
-            ctObj.spans = XmlHelper.ReadString(node.Attributes["spans"]);
+            string rawSpans = XmlHelper.ReadString(node.Attributes["spans"]);
+            ctObj.spans = rawSpans != null ? string.Intern(rawSpans) : null;
             ctObj.s = XmlHelper.ReadUInt(node.Attributes["s"]);
             ctObj.customFormat = XmlHelper.ReadBool(node.Attributes["customFormat"]);
             ctObj.dyDescentField = XmlHelper.ReadDouble(node.Attributes["x14ac:dyDescent"]);
-            if (node.Attributes["ht"]!=null)
+            if (node.Attributes["ht"] != null)
                 ctObj.ht = XmlHelper.ReadDouble(node.Attributes["ht"]);
             ctObj.hidden = XmlHelper.ReadBool(node.Attributes["hidden"]);
             ctObj.outlineLevel = XmlHelper.ReadByte(node.Attributes["outlineLevel"]);
@@ -67,7 +73,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             ctObj.thickTop = XmlHelper.ReadBool(node.Attributes["thickTop"]);
             ctObj.thickBot = XmlHelper.ReadBool(node.Attributes["thickBot"]);
             ctObj.ph = XmlHelper.ReadBool(node.Attributes["ph"]);
-            ctObj.c = new List<CT_Cell>();
+            ctObj.c = new List<CT_Cell>(node.ChildNodes.Count);
             foreach (XmlNode childNode in node.ChildNodes)
             {
                 if (childNode.LocalName == "extLst")
@@ -107,15 +113,15 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             XmlHelper.WriteAttribute(sw, "r", this.r);
             XmlHelper.WriteAttribute(sw, "spans", this.spans);
             XmlHelper.WriteAttribute(sw, "s", this.s);
-            XmlHelper.WriteAttribute(sw, "customFormat", this.customFormat,false);
-            if (this.ht>=0)
+            XmlHelper.WriteAttribute(sw, "customFormat", this.customFormat, false);
+            if (this.ht >= 0)
                 XmlHelper.WriteAttribute(sw, "ht", this.ht);
-            XmlHelper.WriteAttribute(sw, "hidden", this.hidden,false);
-            XmlHelper.WriteAttribute(sw, "customHeight", this.customHeight,false);
+            XmlHelper.WriteAttribute(sw, "hidden", this.hidden, false);
+            XmlHelper.WriteAttribute(sw, "customHeight", this.customHeight, false);
             XmlHelper.WriteAttribute(sw, "outlineLevel", this.outlineLevel);
             XmlHelper.WriteAttribute(sw, "collapsed", this.collapsed, false);
-            XmlHelper.WriteAttribute(sw, "thickTop", this.thickTop,false);
-            XmlHelper.WriteAttribute(sw, "thickBot", this.thickBot,false);
+            XmlHelper.WriteAttribute(sw, "thickTop", this.thickTop, false);
+            XmlHelper.WriteAttribute(sw, "thickBot", this.thickBot, false);
             XmlHelper.WriteAttribute(sw, "ph", this.ph, false);
             XmlHelper.WriteAttribute(sw, "x14ac:dyDescent", this.dyDescentField, false);
             sw.Write(">");
@@ -140,26 +146,21 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
             rField = row.rField;
             spansField = row.spansField;
             sField = row.sField;
-            customFormatField = row.customFormatField;
+            _flags = row._flags;
             htField = row.htField;
-            hiddenField = row.hiddenField;
-            customHeightField = row.customHeightField;
             outlineLevelField = row.outlineLevelField;
-            collapsedField = row.collapsedField;
-            thickTopField = row.thickTopField;
-            thickBotField = row.thickBotField;
-            phField = row.phField;
         }
         public CT_Cell AddNewC()
         {
-            if (null == cField) { cField = new List<CT_Cell>(); }
+            if (null == cField)
+            { cField = new List<CT_Cell>(); }
             CT_Cell cell = new CT_Cell();
             this.cField.Add(cell);
             return cell;
         }
         public void UnsetCollapsed()
         {
-            this.collapsedField = false;
+            _flags &= ~RowFlags.Collapsed;
         }
         public void UnsetS()
         {
@@ -167,19 +168,19 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public void UnsetCustomFormat()
         {
-            this.customFormatField = false;
+            _flags &= ~RowFlags.CustomFormat;
         }
         public bool IsSetHidden()
         {
-            return this.hiddenField != false;
+            return (_flags & RowFlags.Hidden) != 0;
         }
         public bool IsSetCollapsed()
         {
-            return this.collapsedField != false;
+            return (_flags & RowFlags.Collapsed) != 0;
         }
         public bool IsSetHt()
         {
-            return this.htField >=0;
+            return this.htField >= 0;
         }
         public void UnsetHt()
         {
@@ -187,11 +188,11 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public bool IsSetCustomHeight()
         {
-            return this.customHeightField != false;
+            return (_flags & RowFlags.CustomHeight) != 0;
         }
         public void UnsetCustomHeight()
         {
-            this.customHeightField = false;
+            _flags &= ~RowFlags.CustomHeight;
         }
         public bool IsSetS()
         {
@@ -199,7 +200,7 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         }
         public void UnsetHidden()
         {
-            this.hiddenField = false;
+            _flags &= ~RowFlags.Hidden;
         }
 
         public int SizeOfCArray()
@@ -285,11 +286,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return this.customFormatField;
+                return (_flags & RowFlags.CustomFormat) != 0;
             }
             set
             {
-                this.customFormatField = value;
+                if (value)
+                    _flags |= RowFlags.CustomFormat;
+                else
+                    _flags &= ~RowFlags.CustomFormat;
             }
         }
         [XmlAttribute]
@@ -312,11 +316,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return this.hiddenField;
+                return (_flags & RowFlags.Hidden) != 0;
             }
             set
             {
-                this.hiddenField = value;
+                if (value)
+                    _flags |= RowFlags.Hidden;
+                else
+                    _flags &= ~RowFlags.Hidden;
             }
         }
 
@@ -326,11 +333,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return this.customHeightField;
+                return (_flags & RowFlags.CustomHeight) != 0;
             }
             set
             {
-                this.customHeightField = value;
+                if (value)
+                    _flags |= RowFlags.CustomHeight;
+                else
+                    _flags &= ~RowFlags.CustomHeight;
             }
         }
 
@@ -354,11 +364,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return this.collapsedField;
+                return (_flags & RowFlags.Collapsed) != 0;
             }
             set
             {
-                this.collapsedField = value;
+                if (value)
+                    _flags |= RowFlags.Collapsed;
+                else
+                    _flags &= ~RowFlags.Collapsed;
             }
         }
 
@@ -368,11 +381,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return this.thickTopField;
+                return (_flags & RowFlags.ThickTop) != 0;
             }
             set
             {
-                this.thickTopField = value;
+                if (value)
+                    _flags |= RowFlags.ThickTop;
+                else
+                    _flags &= ~RowFlags.ThickTop;
             }
         }
 
@@ -382,11 +398,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return this.thickBotField;
+                return (_flags & RowFlags.ThickBot) != 0;
             }
             set
             {
-                this.thickBotField = value;
+                if (value)
+                    _flags |= RowFlags.ThickBot;
+                else
+                    _flags &= ~RowFlags.ThickBot;
             }
         }
 
@@ -396,11 +415,14 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
         {
             get
             {
-                return this.phField;
+                return (_flags & RowFlags.Ph) != 0;
             }
             set
             {
-                this.phField = value;
+                if (value)
+                    _flags |= RowFlags.Ph;
+                else
+                    _flags &= ~RowFlags.Ph;
             }
         }
 

--- a/OpenXmlFormats/Spreadsheet/Sheet/CT_SheetData.cs
+++ b/OpenXmlFormats/Spreadsheet/Sheet/CT_SheetData.cs
@@ -133,5 +133,18 @@ namespace NPOI.OpenXmlFormats.Spreadsheet
                 return this.lastColumnField;
             }
         }
+
+        /// <summary>
+        /// Updates the lastColumn tracking field if the given value is larger than
+        /// the current value. Used by streaming parsers that add rows individually
+        /// rather than through the static Parse method.
+        /// </summary>
+        public void UpdateLastColumn(int cellIndex)
+        {
+            if (cellIndex > lastColumnField)
+            {
+                lastColumnField = cellIndex;
+            }
+        }
     }
 }

--- a/ooxml/Iron/XSSF/UserModel/XSSFCellExtension.cs
+++ b/ooxml/Iron/XSSF/UserModel/XSSFCellExtension.cs
@@ -13,26 +13,26 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         public void EnsureStyleConsideringColumnStyle()
         {
-            if ((GetStylesSource() != null) && (GetStylesSource().NumCellStyles > 0))
+            var styles = GetStylesSource();
+            if (styles == null || styles.NumCellStyles == 0)
+                return;
+
+            long idx = 0;
+            if (_cell.IsSetS())
             {
-                long idx = 0;
-
-                if (_cell.IsSetS())
-                {
-                    idx = _cell.s;
-                }
-                else if (Sheet.GetColumnStyle(ColumnIndex) != null)
-                {
-                    idx = Sheet.GetColumnStyle(ColumnIndex).Index;
-                }
-
-                if (_cell.IsSetS())
-                {
-                    _cell.unsetS();
-                }
-
-                _cell.s = (uint)idx;
+                idx = _cell.s;
             }
+            else if (Sheet.GetColumnStyle(ColumnIndex) != null)
+            {
+                idx = Sheet.GetColumnStyle(ColumnIndex).Index;
+            }
+
+            if (_cell.IsSetS())
+            {
+                _cell.unsetS();
+            }
+
+            _cell.s = (uint)idx;
         }
     }
 }

--- a/ooxml/Iron/XSSF/UserModel/XSSFCellExtension.cs
+++ b/ooxml/Iron/XSSF/UserModel/XSSFCellExtension.cs
@@ -1,4 +1,5 @@
-﻿using NPOI.SS.UserModel;
+﻿using NPOI.OpenXmlFormats.Spreadsheet;
+using NPOI.SS.UserModel;
 
 namespace NPOI.XSSF.UserModel
 {
@@ -12,7 +13,7 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         public void EnsureStyleConsideringColumnStyle()
         {
-            if ((_stylesSource != null) && (_stylesSource.NumCellStyles > 0))
+            if ((GetStylesSource() != null) && (GetStylesSource().NumCellStyles > 0))
             {
                 long idx = 0;
 

--- a/ooxml/POIXMLDocumentPart.cs
+++ b/ooxml/POIXMLDocumentPart.cs
@@ -809,6 +809,12 @@ namespace NPOI
                 }
             }
 
+            // === MEMORY DIAGNOSTIC ===
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Console.WriteLine($"[MEM-DIAG] POIXMLDocumentPart.Read: part={pp.PartName?.Name ?? "?"}, {readLater.Count} children to read, mem={GC.GetTotalMemory(false):N0}");
+            // === END ===
+
             foreach (POIXMLDocumentPart childPart in readLater)
             {
                 childPart.Read(factory, context);

--- a/ooxml/POIXMLDocumentPart.cs
+++ b/ooxml/POIXMLDocumentPart.cs
@@ -809,12 +809,6 @@ namespace NPOI
                 }
             }
 
-            // === MEMORY DIAGNOSTIC ===
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            Console.WriteLine($"[MEM-DIAG] POIXMLDocumentPart.Read: part={pp.PartName?.Name ?? "?"}, {readLater.Count} children to read, mem={GC.GetTotalMemory(false):N0}");
-            // === END ===
-
             foreach (POIXMLDocumentPart childPart in readLater)
             {
                 childPart.Read(factory, context);

--- a/ooxml/SS/UserModel/WorkbookFactory.cs
+++ b/ooxml/SS/UserModel/WorkbookFactory.cs
@@ -133,19 +133,7 @@ namespace NPOI.SS.UserModel
             inputStream.Position = 0;
             if (DocumentFactoryHelper.HasOOXMLHeader(inputStream))
             {
-                // === MEMORY DIAGNOSTIC ===
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Console.WriteLine($"[MEM-DIAG] Before OPCPackage.Open: {GC.GetTotalMemory(false):N0} bytes");
-                // === END ===
                 OPCPackage pkg = OPCPackage.Open(inputStream, readOnly);
-
-                // === MEMORY DIAGNOSTIC ===
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Console.WriteLine($"[MEM-DIAG] After OPCPackage.Open (ZIP decompressed): {GC.GetTotalMemory(false):N0} bytes");
-                // === END ===
-
                 return new XSSFWorkbook(pkg);
             }
             throw new InvalidFormatException("Your stream was neither an OLE2 stream, nor an OOXML stream.");

--- a/ooxml/SS/UserModel/WorkbookFactory.cs
+++ b/ooxml/SS/UserModel/WorkbookFactory.cs
@@ -133,7 +133,20 @@ namespace NPOI.SS.UserModel
             inputStream.Position = 0;
             if (DocumentFactoryHelper.HasOOXMLHeader(inputStream))
             {
-                return new XSSFWorkbook(OPCPackage.Open(inputStream, readOnly));
+                // === MEMORY DIAGNOSTIC ===
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Console.WriteLine($"[MEM-DIAG] Before OPCPackage.Open: {GC.GetTotalMemory(false):N0} bytes");
+                // === END ===
+                OPCPackage pkg = OPCPackage.Open(inputStream, readOnly);
+
+                // === MEMORY DIAGNOSTIC ===
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Console.WriteLine($"[MEM-DIAG] After OPCPackage.Open (ZIP decompressed): {GC.GetTotalMemory(false):N0} bytes");
+                // === END ===
+
+                return new XSSFWorkbook(pkg);
             }
             throw new InvalidFormatException("Your stream was neither an OLE2 stream, nor an OOXML stream.");
         }

--- a/ooxml/SS/UserModel/WorkbookFactory.cs
+++ b/ooxml/SS/UserModel/WorkbookFactory.cs
@@ -133,8 +133,7 @@ namespace NPOI.SS.UserModel
             inputStream.Position = 0;
             if (DocumentFactoryHelper.HasOOXMLHeader(inputStream))
             {
-                OPCPackage pkg = OPCPackage.Open(inputStream, readOnly);
-                return new XSSFWorkbook(pkg);
+                return new XSSFWorkbook(OPCPackage.Open(inputStream, readOnly));
             }
             throw new InvalidFormatException("Your stream was neither an OLE2 stream, nor an OOXML stream.");
         }

--- a/ooxml/XSSF/Model/CalculationChain.cs
+++ b/ooxml/XSSF/Model/CalculationChain.cs
@@ -47,6 +47,11 @@ namespace NPOI.XSSF.Model
         {
             XmlDocument xml = ConvertStreamToXml(part.GetInputStream());
             ReadFrom(xml);
+
+            if (part is ZipPackagePart zipPart)
+            {
+                zipPart.ReleaseZipEntryData();
+            }
         }
 
         [Obsolete("deprecated in POI 3.14, scheduled for removal in POI 3.16")]

--- a/ooxml/XSSF/Model/SharedStringsTable.cs
+++ b/ooxml/XSSF/Model/SharedStringsTable.cs
@@ -85,7 +85,7 @@ namespace NPOI.XSSF.Model
         /// This avoids loading the full shared strings XML into an XmlDocument DOM tree,
         /// which can use 3-10x the XML size in memory.
         /// </summary>
-        private const long StreamingParseThreshold = 1 * 1024 * 1024; // 5MB
+        private const long StreamingParseThreshold = 1 * 1024 * 1024; // 1MB
 
         public SharedStringsTable()
             : base()

--- a/ooxml/XSSF/Model/SharedStringsTable.cs
+++ b/ooxml/XSSF/Model/SharedStringsTable.cs
@@ -122,12 +122,6 @@ namespace NPOI.XSSF.Model
             {
                 long streamLength = is1.CanSeek ? is1.Length : -1;
 
-                // === MEMORY DIAGNOSTIC ===
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Console.WriteLine($"[MEM-DIAG] SharedStringsTable.ReadFrom START: stream={streamLength:N0} bytes, threshold={StreamingParseThreshold:N0}, mode={(streamLength > StreamingParseThreshold ? "STREAMING" : "DOM")}, mem={GC.GetTotalMemory(false):N0}");
-                // === END ===
-
                 if (streamLength > StreamingParseThreshold)
                 {
                     ReadFromStreaming(is1);
@@ -136,12 +130,6 @@ namespace NPOI.XSSF.Model
                 {
                     ReadFromDom(is1);
                 }
-
-                // === MEMORY DIAGNOSTIC ===
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Console.WriteLine($"[MEM-DIAG] SharedStringsTable.ReadFrom DONE: uniqueStrings={strings.Count}, mem={GC.GetTotalMemory(false):N0} bytes");
-                // === END ===
             }
             catch (XmlException e)
             {

--- a/ooxml/XSSF/Model/SharedStringsTable.cs
+++ b/ooxml/XSSF/Model/SharedStringsTable.cs
@@ -80,6 +80,13 @@ namespace NPOI.XSSF.Model
 
         private SstDocument _sstDoc;
 
+        /// <summary>
+        /// Threshold in bytes above which streaming XML parse is used instead of DOM.
+        /// This avoids loading the full shared strings XML into an XmlDocument DOM tree,
+        /// which can use 3-10x the XML size in memory.
+        /// </summary>
+        private const long StreamingParseThreshold = 1 * 1024 * 1024; // 5MB
+
         public SharedStringsTable()
             : base()
         {
@@ -92,6 +99,14 @@ namespace NPOI.XSSF.Model
             : base(part)
         {
             ReadFrom(part.GetInputStream());
+
+            // Release the decompressed ZIP entry data for the shared strings table.
+            // The data has been fully parsed into the CT_Rst object model and is no
+            // longer needed. Commit() regenerates the XML from the model during save.
+            if (part is ZipPackagePart zipPart)
+            {
+                zipPart.ReleaseZipEntryData();
+            }
         }
 
         [Obsolete("deprecated in POI 3.14, scheduled for removal in POI 3.16")]
@@ -105,20 +120,28 @@ namespace NPOI.XSSF.Model
         {
             try
             {
-                int cnt = 0;
-                XmlDocument xml = ConvertStreamToXml(is1);
-                _sstDoc = SstDocument.Parse(xml, NamespaceManager);
-                CT_Sst sst = _sstDoc.GetSst();
-                count = (int)sst.count;
-                uniqueCount = (int)sst.uniqueCount;
-                foreach (CT_Rst st in sst.si)
+                long streamLength = is1.CanSeek ? is1.Length : -1;
+
+                // === MEMORY DIAGNOSTIC ===
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Console.WriteLine($"[MEM-DIAG] SharedStringsTable.ReadFrom START: stream={streamLength:N0} bytes, threshold={StreamingParseThreshold:N0}, mode={(streamLength > StreamingParseThreshold ? "STREAMING" : "DOM")}, mem={GC.GetTotalMemory(false):N0}");
+                // === END ===
+
+                if (streamLength > StreamingParseThreshold)
                 {
-                    string key = GetKey(st);
-                    if (key != null && !stmap.ContainsKey(key))
-                        stmap.Add(key, cnt);
-                    strings.Add(st);
-                    cnt++;
+                    ReadFromStreaming(is1);
                 }
+                else
+                {
+                    ReadFromDom(is1);
+                }
+
+                // === MEMORY DIAGNOSTIC ===
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Console.WriteLine($"[MEM-DIAG] SharedStringsTable.ReadFrom DONE: uniqueStrings={strings.Count}, mem={GC.GetTotalMemory(false):N0} bytes");
+                // === END ===
             }
             catch (XmlException e)
             {
@@ -126,8 +149,109 @@ namespace NPOI.XSSF.Model
             }
         }
 
+        /// <summary>
+        /// Original DOM-based parse for small shared string tables.
+        /// </summary>
+        private void ReadFromDom(Stream is1)
+        {
+            int cnt = 0;
+            XmlDocument xml = ConvertStreamToXml(is1);
+            _sstDoc = SstDocument.Parse(xml, NamespaceManager);
+            CT_Sst sst = _sstDoc.GetSst();
+            count = (int)sst.count;
+            uniqueCount = (int)sst.uniqueCount;
+            foreach (CT_Rst st in sst.si)
+            {
+                string key = GetKey(st);
+                if (key != null && !stmap.ContainsKey(key))
+                    stmap.Add(key, cnt);
+                strings.Add(st);
+                cnt++;
+            }
+        }
+
+        /// <summary>
+        /// Streaming XmlReader-based parse for large shared string tables.
+        /// Avoids loading the entire SST XML into an XmlDocument DOM tree, which
+        /// can use 3-10x the raw XML size in memory. Instead, each individual
+        /// &lt;si&gt; element is parsed as a small DOM subtree.
+        /// </summary>
+        private void ReadFromStreaming(Stream is1)
+        {
+            _sstDoc = new SstDocument();
+            _sstDoc.AddNewSst();
+            CT_Sst sst = _sstDoc.GetSst();
+
+            var readerSettings = new XmlReaderSettings
+            {
+                XmlResolver = null,
+#pragma warning disable CS0618 // ProhibitDtd is obsolete but needed for older .NET targets
+                ProhibitDtd = true,
+#pragma warning restore CS0618
+                CloseInput = false
+            };
+
+            int cnt = 0;
+            XmlDocument siDoc = new XmlDocument();
+
+            using (XmlReader reader = XmlReader.Create(is1, readerSettings))
+            {
+                bool needsRead = true;
+                while (needsRead ? reader.Read() : !reader.EOF)
+                {
+                    needsRead = true;
+
+                    if (reader.NodeType == XmlNodeType.Element)
+                    {
+                        if (reader.LocalName == "sst")
+                        {
+                            string countStr = reader.GetAttribute("count");
+                            string uniqueStr = reader.GetAttribute("uniqueCount");
+                            if (countStr != null && int.TryParse(countStr, out int c))
+                                count = c;
+                            if (uniqueStr != null && int.TryParse(uniqueStr, out int uc))
+                                uniqueCount = uc;
+
+                            sst.count = count;
+                            sst.uniqueCount = uniqueCount;
+
+                            // Pre-allocate with known capacity
+                            if (uniqueCount > 0)
+                            {
+                                strings = new List<CT_Rst>(uniqueCount);
+                                stmap = new Dictionary<string, int>(uniqueCount);
+                            }
+                            // "sst" is a container element — let Read() advance into children
+                        }
+                        else if (reader.LocalName == "si")
+                        {
+                            // Read the <si> subtree into a small XmlDocument for CT_Rst.Parse
+
+                            siDoc.RemoveAll();
+                            siDoc.LoadXml(reader.ReadOuterXml());
+
+                            CT_Rst rst = CT_Rst.Parse(siDoc.DocumentElement, NamespaceManager);
+                            string key = GetKey(rst);
+                            if (key != null && !stmap.ContainsKey(key))
+                                stmap.Add(key, cnt);
+                            strings.Add(rst);
+                            sst.si.Add(rst);
+                            cnt++;
+                            needsRead = false; // ReadOuterXml already advanced
+                        }
+                    }
+                }
+            }
+        }
+
         private String GetKey(CT_Rst st)
         {
+            // Optimization: for simple strings (no rich text), use the t field directly.
+            // This avoids building and caching the full XmlText representation.
+            if (st.IsSetT() && st.sizeOfRArray() == 0)
+            {
+                return st.t;
+            }
             return st.XmlText;
         }
 
@@ -215,9 +339,9 @@ namespace NPOI.XSSF.Model
         }
 
         /**
-         * 
+         *
          * this table out as XML.
-         * 
+         *
          * @param out The stream to write to.
          * @throws IOException if an error occurs while writing.
          */
@@ -246,9 +370,3 @@ namespace NPOI.XSSF.Model
         }
     }
 }
-
-
-
-
-
-

--- a/ooxml/XSSF/Model/StylesTable.cs
+++ b/ooxml/XSSF/Model/StylesTable.cs
@@ -117,6 +117,12 @@ namespace NPOI.XSSF.Model
         {
             XmlDocument xmldoc = ConvertStreamToXml(part.GetInputStream());
             ReadFrom(xmldoc);
+
+            // Release decompressed ZIP entry data after parsing
+            if (part is ZipPackagePart zipPart)
+            {
+                zipPart.ReleaseZipEntryData();
+            }
         }
 
         [Obsolete("deprecated in POI 3.14, scheduled for removal in POI 3.16")]

--- a/ooxml/XSSF/UserModel/XSSFCell.cs
+++ b/ooxml/XSSF/UserModel/XSSFCell.cs
@@ -88,7 +88,7 @@ namespace NPOI.XSSF.UserModel
                 {
                     _cellNum = (row as XSSFRow).GetCell(prevNum - 1, MissingCellPolicy.RETURN_NULL_AND_BLANK).ColumnIndex + 1;
                 }
-            }  
+            }
         }
 
         /// <summary>
@@ -522,9 +522,11 @@ namespace NPOI.XSSF.UserModel
                     {
                         _cell.t = ST_CellType.s;
                         XSSFRichTextString rt = (XSSFRichTextString)str;
-                        rt.SetStylesTableReference(GetStylesSource());
-                        int sRef = GetSharedStringSource().AddEntry(rt.GetCTRst());
-                        _cell.v=sRef.ToString();
+                        var styles = GetStylesSource();
+                        var sst = GetSharedStringSource();
+                        rt.SetStylesTableReference(styles);
+                        int sRef = sst.AddEntry(rt.GetCTRst());
+                        _cell.v = sRef.ToString();
                     }
                     break;
             }
@@ -748,26 +750,26 @@ namespace NPOI.XSSF.UserModel
         {
             get
             {
-                XSSFCellStyle style = null;
-                if ((null != GetStylesSource()) && (GetStylesSource().NumCellStyles > 0))
-                {
-                    long idx = _cell.IsSetS() ? _cell.s : 0;
-                    style = GetStylesSource().GetStyleAt((int)idx);
-                }
-                return style;
+                var styles = GetStylesSource();
+                if (styles == null || styles.NumCellStyles == 0)
+                    return null;
+                long idx = _cell.IsSetS() ? _cell.s : 0;
+                return styles.GetStyleAt((int)idx);
             }
-            set 
+            set
             {
                 if (value == null)
                 {
-                    if (_cell.IsSetS()) _cell.unsetS();
+                    if (_cell.IsSetS())
+                        _cell.unsetS();
                 }
                 else
                 {
                     XSSFCellStyle xStyle = (XSSFCellStyle)value;
-                    xStyle.VerifyBelongsToStylesSource(GetStylesSource());
+                    var styles = GetStylesSource();
+                    xStyle.VerifyBelongsToStylesSource(styles);
 
-                    long idx = GetStylesSource().PutStyle(xStyle);
+                    long idx = styles.PutStyle(xStyle);
                     _cell.s = (uint)idx;
                 }
             }
@@ -1063,11 +1065,13 @@ namespace NPOI.XSSF.UserModel
                     {
                         String str = ConvertCellValueToString();
                         XSSFRichTextString rt = new XSSFRichTextString(str);
-                        rt.SetStylesTableReference(GetStylesSource());
-                        int sRef = GetSharedStringSource().AddEntry(rt.GetCTRst());
-                        _cell.v= sRef.ToString();
+                        var styles = GetStylesSource();
+                        var sst = GetSharedStringSource();
+                        rt.SetStylesTableReference(styles);
+                        int sRef = sst.AddEntry(rt.GetCTRst());
+                        _cell.v = sRef.ToString();
                     }
-                    _cell.t= (ST_CellType.s);
+                    _cell.t = (ST_CellType.s);
                     break;
                 case CellType.Formula:
                     if (!_cell.IsSetF())

--- a/ooxml/XSSF/UserModel/XSSFCell.cs
+++ b/ooxml/XSSF/UserModel/XSSFCell.cs
@@ -68,17 +68,6 @@ namespace NPOI.XSSF.UserModel
         private int _cellNum;
 
         /**
-         * Table of strings shared across this workbook.
-         * If two cells contain the same string, then the cell value is the same index into SharedStringsTable
-         */
-        private SharedStringsTable _sharedStringSource;
-
-        /**
-         * Table of cell styles shared across all cells in a workbook.
-         */
-        private StylesTable _stylesSource;
-
-        /**
          * Construct a XSSFCell.
          *
          * @param row the parent row.
@@ -90,7 +79,7 @@ namespace NPOI.XSSF.UserModel
             _row = row;
             if (cell.r != null)
             {
-                _cellNum = new CellReference(cell.r).Col;
+                _cellNum = ParseColumnIndex(cell.r);
             }
             else
             {
@@ -99,9 +88,7 @@ namespace NPOI.XSSF.UserModel
                 {
                     _cellNum = (row as XSSFRow).GetCell(prevNum - 1, MissingCellPolicy.RETURN_NULL_AND_BLANK).ColumnIndex + 1;
                 }
-            }
-            _sharedStringSource = ((XSSFWorkbook)row.Sheet.Workbook).GetSharedStringSource();
-            _stylesSource = ((XSSFWorkbook)row.Sheet.Workbook).GetStylesSource();
+            }  
         }
 
         /// <summary>
@@ -210,7 +197,7 @@ namespace NPOI.XSSF.UserModel
          */
         protected SharedStringsTable GetSharedStringSource()
         {
-            return _sharedStringSource;
+            return ((XSSFWorkbook)_row.Sheet.Workbook).GetSharedStringSource();
         }
 
         /**
@@ -218,7 +205,7 @@ namespace NPOI.XSSF.UserModel
          */
         protected StylesTable GetStylesSource()
         {
-            return _stylesSource;
+            return ((XSSFWorkbook)_row.Sheet.Workbook).GetStylesSource();
         }
 
         /**
@@ -428,7 +415,7 @@ namespace NPOI.XSSF.UserModel
                             if (_cell.IsSetV())
                             {
                                 int idx = Int32.Parse(_cell.v);
-                                rt = new XSSFRichTextString(_sharedStringSource.GetEntryAt(idx));
+                                rt = new XSSFRichTextString(GetSharedStringSource().GetEntryAt(idx));
                             }
                             else
                             {
@@ -443,9 +430,38 @@ namespace NPOI.XSSF.UserModel
                     default:
                         throw TypeMismatch(CellType.String, cellType, false);
                 }
-                rt.SetStylesTableReference(_stylesSource);
+                rt.SetStylesTableReference(GetStylesSource());
                 return rt;
             }
+        }
+
+        /// <summary>
+        /// Parses the column index directly from a cell reference string (e.g. "A1" → 0, "AA5" → 26)
+        /// without allocating a CellReference object.
+        /// </summary>
+        private static int ParseColumnIndex(string cellRef)
+        {
+            int col = 0;
+            int i = 0;
+            while (i < cellRef.Length)
+            {
+                char c = cellRef[i];
+                if (c >= 'A' && c <= 'Z')
+                {
+                    col = col * 26 + (c - 'A' + 1);
+                    i++;
+                }
+                else if (c >= 'a' && c <= 'z')
+                {
+                    col = col * 26 + (c - 'a' + 1);
+                    i++;
+                }
+                else
+                {
+                    break; // hit digit, we're done with column letters
+                }
+            }
+            return col - 1; // 0-based
         }
 
         private static void CheckFormulaCachedValueType(CellType expectedTypeCode, CellType cachedValueType)
@@ -506,8 +522,8 @@ namespace NPOI.XSSF.UserModel
                     {
                         _cell.t = ST_CellType.s;
                         XSSFRichTextString rt = (XSSFRichTextString)str;
-                        rt.SetStylesTableReference(_stylesSource);
-                        int sRef = _sharedStringSource.AddEntry(rt.GetCTRst());
+                        rt.SetStylesTableReference(GetStylesSource());
+                        int sRef = GetSharedStringSource().AddEntry(rt.GetCTRst());
                         _cell.v=sRef.ToString();
                     }
                     break;
@@ -733,10 +749,10 @@ namespace NPOI.XSSF.UserModel
             get
             {
                 XSSFCellStyle style = null;
-                if ((null != _stylesSource) && (_stylesSource.NumCellStyles > 0))
+                if ((null != GetStylesSource()) && (GetStylesSource().NumCellStyles > 0))
                 {
                     long idx = _cell.IsSetS() ? _cell.s : 0;
-                    style = _stylesSource.GetStyleAt((int)idx);
+                    style = GetStylesSource().GetStyleAt((int)idx);
                 }
                 return style;
             }
@@ -749,9 +765,9 @@ namespace NPOI.XSSF.UserModel
                 else
                 {
                     XSSFCellStyle xStyle = (XSSFCellStyle)value;
-                    xStyle.VerifyBelongsToStylesSource(_stylesSource);
+                    xStyle.VerifyBelongsToStylesSource(GetStylesSource());
 
-                    long idx = _stylesSource.PutStyle(xStyle);
+                    long idx = GetStylesSource().PutStyle(xStyle);
                     _cell.s = (uint)idx;
                 }
             }
@@ -1047,8 +1063,8 @@ namespace NPOI.XSSF.UserModel
                     {
                         String str = ConvertCellValueToString();
                         XSSFRichTextString rt = new XSSFRichTextString(str);
-                        rt.SetStylesTableReference(_stylesSource);
-                        int sRef = _sharedStringSource.AddEntry(rt.GetCTRst());
+                        rt.SetStylesTableReference(GetStylesSource());
+                        int sRef = GetSharedStringSource().AddEntry(rt.GetCTRst());
                         _cell.v= sRef.ToString();
                     }
                     _cell.t= (ST_CellType.s);
@@ -1267,7 +1283,7 @@ namespace NPOI.XSSF.UserModel
                     return TRUE_AS_STRING.Equals(_cell.v);
                 case CellType.String:
                     int sstIndex = Int32.Parse(_cell.v);
-                    XSSFRichTextString rt = new XSSFRichTextString(_sharedStringSource.GetEntryAt(sstIndex));
+                    XSSFRichTextString rt = new XSSFRichTextString(GetSharedStringSource().GetEntryAt(sstIndex));
                     String text = rt.String;
                     return Boolean.Parse(text);
                 case CellType.Numeric:
@@ -1292,7 +1308,7 @@ namespace NPOI.XSSF.UserModel
                     return TRUE_AS_STRING.Equals(_cell.v) ? "TRUE" : "FALSE";
                 case CellType.String:
                     int sstIndex = Int32.Parse(_cell.v);
-                    XSSFRichTextString rt = new XSSFRichTextString(_sharedStringSource.GetEntryAt(sstIndex));
+                    XSSFRichTextString rt = new XSSFRichTextString(GetSharedStringSource().GetEntryAt(sstIndex));
                     return rt.String;
                 case CellType.Numeric:
                 case CellType.Error:

--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -228,13 +228,12 @@ namespace NPOI.XSSF.UserModel
         {
             get
             {
-                if (IsFormatted && ((XSSFWorkbook)_sheet.Workbook).GetStylesSource() != null
-                    && ((XSSFWorkbook)_sheet.Workbook).GetStylesSource().NumCellStyles > 0)
-                {
-                    return ((XSSFWorkbook)_sheet.Workbook).GetStylesSource().GetStyleAt((int)_row.s);
-                }
-
-                return null;
+                if (!IsFormatted)
+                    return null;
+                var styles = ((XSSFWorkbook)_sheet.Workbook).GetStylesSource();
+                if (styles == null || styles.NumCellStyles == 0)
+                    return null;
+                return styles.GetStyleAt((int)_row.s);
             }
 
             set
@@ -250,9 +249,10 @@ namespace NPOI.XSSF.UserModel
                 else
                 {
                     XSSFCellStyle xStyle = (XSSFCellStyle)value;
-                    xStyle.VerifyBelongsToStylesSource(((XSSFWorkbook)_sheet.Workbook).GetStylesSource());
+                    var styles = ((XSSFWorkbook)_sheet.Workbook).GetStylesSource();
+                    xStyle.VerifyBelongsToStylesSource(styles);
 
-                    long idx = ((XSSFWorkbook)_sheet.Workbook).GetStylesSource().PutStyle(xStyle);
+                    long idx = styles.PutStyle(xStyle);
                     _row.s = (uint)idx;
                     _row.customFormat = true;
                 }
@@ -629,12 +629,30 @@ namespace NPOI.XSSF.UserModel
         }
 
         /// <summary>
-        /// Regenerates any null CT_Cell.r reference strings that were released during
-        /// load to save memory. Called before save or any operation that needs cell
-        /// reference strings (sorting, ordering checks).
+        /// Regenerates any null CT_Cell.r reference strings.
+        /// <para>
+        /// Background: a previous optimisation released CT_Cell.r after extracting the
+        /// column index in the XSSFCell constructor, to save ~36 B per cell. That
+        /// optimisation has since been reverted because <see cref="CT_Cell.IsSetR"/>,
+        /// <see cref="RebuildCells"/> sort, and several other paths require the
+        /// reference to be populated. This method remains as a safety net so that
+        /// any future code that nulls <see cref="CT_Cell.r"/> for memory will not
+        /// produce a corrupted save.
+        /// </para>
+        /// <para>
+        /// Performance: on a workbook loaded normally, every cell already has
+        /// <c>ct.r != null</c> from <see cref="CT_Cell.Parse"/>, so the condition
+        /// short-circuits on the very first iteration of every cell with no
+        /// allocation. Cost is one bounds-check + one ref-comparison per cell.
+        /// </para>
         /// </summary>
         private void EnsureCellRefsPopulated()
         {
+            // Fast path: if the row's CT_Cell list and the wrapper map are out of
+            // sync, do nothing - RebuildCells / OnDocumentWrite will reconcile.
+            if (_cells.Count == 0)
+                return;
+
             uint rowNum = _row.r;
             foreach (ICell cell in _cells.Values)
             {
@@ -650,9 +668,27 @@ namespace NPOI.XSSF.UserModel
 
         #region IEnumerable and IComparable members
         /// <summary>
-        /// Cell iterator over the physically defined cell
+        /// Cell iterator over the physically defined cells, ordered by column index.
+        /// <para>
+        /// <b>API break vs. prior versions:</b> the concrete return type changed from
+        /// <c>SortedDictionary&lt;int, ICell&gt;.ValueCollection.Enumerator</c> to
+        /// <see cref="IEnumerator{T}"/> of <see cref="ICell"/>. This is because the
+        /// underlying storage switched from <see cref="SortedDictionary{TKey,TValue}"/>
+        /// (which exposes a concrete struct <c>ValueCollection.Enumerator</c>) to
+        /// <see cref="SortedList{TKey,TValue}"/> (whose <c>Values</c> property returns
+        /// <see cref="IList{T}"/> with no concrete struct enumerator accessible
+        /// externally). The memory saving from the storage change is hundreds of MB on
+        /// 10M+-cell workbooks, at the cost of one extra interface allocation per
+        /// call to this method (negligible in normal use — this is an iteration-
+        /// initialising API, not a hot per-cell call).
+        /// </para>
+        /// <para>
+        /// Callers that were pinned to the old concrete type must update their
+        /// variable declarations. Callers using <c>var</c>, <c>foreach</c>, or
+        /// <see cref="IEnumerator{T}"/> are unaffected.
+        /// </para>
         /// </summary>
-        /// <returns>an iterator over cells in this row.</returns>
+        /// <returns>an iterator over cells in this row, in ascending column order.</returns>
         public IEnumerator<ICell> CellIterator()
         {
             return _cells.Values.GetEnumerator();

--- a/ooxml/XSSF/UserModel/XSSFRow.cs
+++ b/ooxml/XSSF/UserModel/XSSFRow.cs
@@ -46,16 +46,14 @@ namespace NPOI.XSSF.UserModel
 
         /// <summary>
         /// Cells of this row keyed by their column indexes.
-        /// The SortedDictionary ensures that the cells are ordered by columnIndex in the ascending order.
         /// </summary>
-        private readonly SortedDictionary<int, ICell> _cells;
+        private readonly SortedList<int, ICell> _cells;
 
         /// <summary>
         /// the parent sheet
         /// </summary>
         private readonly XSSFSheet _sheet;
 
-        private readonly StylesTable _stylesSource;
         #endregion
 
         #region Public properties
@@ -230,10 +228,10 @@ namespace NPOI.XSSF.UserModel
         {
             get
             {
-                if (IsFormatted && _stylesSource != null
-                    && _stylesSource.NumCellStyles > 0)
+                if (IsFormatted && ((XSSFWorkbook)_sheet.Workbook).GetStylesSource() != null
+                    && ((XSSFWorkbook)_sheet.Workbook).GetStylesSource().NumCellStyles > 0)
                 {
-                    return _stylesSource.GetStyleAt((int)_row.s);
+                    return ((XSSFWorkbook)_sheet.Workbook).GetStylesSource().GetStyleAt((int)_row.s);
                 }
 
                 return null;
@@ -252,9 +250,9 @@ namespace NPOI.XSSF.UserModel
                 else
                 {
                     XSSFCellStyle xStyle = (XSSFCellStyle)value;
-                    xStyle.VerifyBelongsToStylesSource(_stylesSource);
+                    xStyle.VerifyBelongsToStylesSource(((XSSFWorkbook)_sheet.Workbook).GetStylesSource());
 
-                    long idx = _stylesSource.PutStyle(xStyle);
+                    long idx = ((XSSFWorkbook)_sheet.Workbook).GetStylesSource().PutStyle(xStyle);
                     _row.s = (uint)idx;
                     _row.customFormat = true;
                 }
@@ -277,7 +275,7 @@ namespace NPOI.XSSF.UserModel
         {
             _row = row;
             _sheet = sheet;
-            _cells = new SortedDictionary<int, ICell>();
+            _cells = new SortedList<int, ICell>(row.SizeOfCArray());
             if (0 < row.SizeOfCArray())
             {
                 foreach (CT_Cell c in row.c)
@@ -300,8 +298,6 @@ namespace NPOI.XSSF.UserModel
 
                 row.r = (uint)nextRowNum;
             }
-
-            _stylesSource = ((XSSFWorkbook)sheet.Workbook).GetStylesSource();
         }
         #endregion
 
@@ -536,6 +532,8 @@ namespace NPOI.XSSF.UserModel
         /// </summary>
         internal void OnDocumentWrite()
         {
+            EnsureCellRefsPopulated();
+
             // check if cells in the CT_Row are ordered
             bool isOrdered = true;
             if (_row.SizeOfCArray() != _cells.Count)
@@ -623,9 +621,31 @@ namespace NPOI.XSSF.UserModel
                 _cells.Add(kv.Key, kv.Value);
             }
 
+            // Regenerate cell reference strings released during load to save memory
+            EnsureCellRefsPopulated();
+
             // Sort CT_Cols by index asc.
             _row.c.Sort((col1, col2) => col1.r.CompareTo(col2.r));
         }
+
+        /// <summary>
+        /// Regenerates any null CT_Cell.r reference strings that were released during
+        /// load to save memory. Called before save or any operation that needs cell
+        /// reference strings (sorting, ordering checks).
+        /// </summary>
+        private void EnsureCellRefsPopulated()
+        {
+            uint rowNum = _row.r;
+            foreach (ICell cell in _cells.Values)
+            {
+                CT_Cell ct = ((XSSFCell)cell).GetCTCell();
+                if (ct.r == null)
+                {
+                    ct.r = CellReference.ConvertNumToColString(cell.ColumnIndex) + rowNum;
+                }
+            }
+        }
+
         #endregion
 
         #region IEnumerable and IComparable members
@@ -633,7 +653,7 @@ namespace NPOI.XSSF.UserModel
         /// Cell iterator over the physically defined cell
         /// </summary>
         /// <returns>an iterator over cells in this row.</returns>
-        public SortedDictionary<int, ICell>.ValueCollection.Enumerator CellIterator()
+        public IEnumerator<ICell> CellIterator()
         {
             return _cells.Values.GetEnumerator();
         }
@@ -800,12 +820,12 @@ namespace NPOI.XSSF.UserModel
 
         private int GetFirstKey()
         {
-            return _cells.Keys.Min();
+            return _cells.Keys[0];
         }
 
         private int GetLastKey()
         {
-            return _cells.Keys.Max();
+            return _cells.Keys[_cells.Count - 1];
         }
         #endregion
     }

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -1267,7 +1267,7 @@ namespace NPOI.XSSF.UserModel
         /// This avoids loading the full sheet XML into an XmlDocument DOM tree, which
         /// can use 3-10x the raw XML size in memory for large sheets.
         /// </summary>
-        private const long StreamingParseThreshold = 1 * 1024 * 1024; // 10MB
+        private const long StreamingParseThreshold = 1 * 1024 * 1024; // 1MB
 
         internal virtual void Read(Stream is1)
         {
@@ -1460,8 +1460,68 @@ namespace NPOI.XSSF.UserModel
                         case "worksheet":
                             // Root element - just let the loop advance into its children
                             break;
+                        case "sheetCalcPr":
+                            worksheet.sheetCalcPr = ParseSubtreeElement<CT_SheetCalcPr>(reader, CT_SheetCalcPr.Parse);
+                            needsRead = false;
+                            break;
+                        case "protectedRanges":
+                            worksheet.protectedRanges = ParseSubtreeElement<CT_ProtectedRanges>(reader, CT_ProtectedRanges.Parse);
+                            needsRead = false;
+                            break;
+                        case "scenarios":
+                            worksheet.scenarios = ParseSubtreeElement<CT_Scenarios>(reader, CT_Scenarios.Parse);
+                            needsRead = false;
+                            break;
+                        case "customSheetViews":
+                            worksheet.customSheetViews = ParseSubtreeElement<CT_CustomSheetViews>(reader, CT_CustomSheetViews.Parse);
+                            needsRead = false;
+                            break;
+                        case "customProperties":
+                            worksheet.customProperties = ParseSubtreeElement<CT_CustomProperties>(reader, CT_CustomProperties.Parse);
+                            needsRead = false;
+                            break;
+                        case "cellWatches":
+                            worksheet.cellWatches = ParseSubtreeElement<CT_CellWatches>(reader, CT_CellWatches.Parse);
+                            needsRead = false;
+                            break;
+                        case "ignoredErrors":
+                            worksheet.ignoredErrors = ParseSubtreeElement<CT_IgnoredErrors>(reader, CT_IgnoredErrors.Parse);
+                            needsRead = false;
+                            break;
+                        case "smartTags":
+                            worksheet.smartTags = ParseSubtreeElement<CT_CellSmartTags>(reader, CT_CellSmartTags.Parse);
+                            needsRead = false;
+                            break;
+                        case "legacyDrawingHF":
+                            worksheet.legacyDrawingHF = ParseSubtreeElement<CT_LegacyDrawing>(reader, CT_LegacyDrawing.Parse);
+                            needsRead = false;
+                            break;
+                        case "picture":
+                            worksheet.picture = ParseSubtreeElement<CT_SheetBackgroundPicture>(reader, CT_SheetBackgroundPicture.Parse);
+                            needsRead = false;
+                            break;
+                        case "oleObjects":
+                            worksheet.oleObjects = ParseSubtreeElement<CT_OleObjects>(reader, CT_OleObjects.Parse);
+                            needsRead = false;
+                            break;
+                        case "controls":
+                            worksheet.controls = ParseSubtreeElement<CT_Controls>(reader, CT_Controls.Parse);
+                            needsRead = false;
+                            break;
+                        case "webPublishItems":
+                            worksheet.webPublishItems = ParseSubtreeElement<CT_WebPublishItems>(reader, CT_WebPublishItems.Parse);
+                            needsRead = false;
+                            break;
+                        case "dataConsolidate":
+                            worksheet.dataConsolidate = ParseSubtreeElement<CT_DataConsolidate>(reader, CT_DataConsolidate.Parse);
+                            needsRead = false;
+                            break;
                         default:
-                            // Unknown element - skip it entirely (advances reader past it)
+                            // Unknown element. Log at debug for diagnostics and skip over the
+                            // subtree so the reader is not left mid-parse. This matches the
+                            // forward-compat behaviour of the DOM path which also drops nodes
+                            // without matching CT_ properties.
+                            logger.Log(POILogger.DEBUG, "ReadStreaming: unhandled sheet element <" + reader.LocalName + "> skipped");
                             reader.Skip();
                             needsRead = false;
                             break;

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -1275,12 +1275,6 @@ namespace NPOI.XSSF.UserModel
             {
                 long streamLength = is1.CanSeek ? is1.Length : -1;
 
-                // === MEMORY DIAGNOSTIC ===
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Console.WriteLine($"[MEM-DIAG] XSSFSheet.Read START: stream={streamLength:N0} bytes, threshold={StreamingParseThreshold:N0}, mode={(streamLength > StreamingParseThreshold ? "STREAMING" : "DOM")}, mem={GC.GetTotalMemory(false):N0}");
-                // === END ===
-
                 if (streamLength > StreamingParseThreshold)
                 {
                     ReadStreaming(is1);
@@ -1288,11 +1282,6 @@ namespace NPOI.XSSF.UserModel
                 else
                 {
                     XmlDocument doc = ConvertStreamToXml(is1);
-                    // === MEMORY DIAGNOSTIC ===
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
-                    Console.WriteLine($"[MEM-DIAG] XSSFSheet.Read: after ConvertStreamToXml (DOM built): {GC.GetTotalMemory(false):N0} bytes");
-                    // === END ===
                     worksheet = WorksheetDocument.Parse(doc, NamespaceManager).GetWorksheet();
                 }
             }
@@ -1301,25 +1290,7 @@ namespace NPOI.XSSF.UserModel
                 throw new POIXMLException(e);
             }
 
-            // === MEMORY DIAGNOSTIC ===
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            int rowCount = worksheet?.sheetData?.SizeOfRowArray() ?? 0;
-            int cellCount = 0;
-            if (worksheet?.sheetData?.row != null)
-                foreach (var r in worksheet.sheetData.row)
-                    cellCount += r.SizeOfCArray();
-            Console.WriteLine($"[MEM-DIAG] XSSFSheet.Read: after parse, before InitRows: rows={rowCount}, cells={cellCount}, mem={GC.GetTotalMemory(false):N0} bytes");
-            // === END ===
-
             InitRows(worksheet);
-
-            // === MEMORY DIAGNOSTIC ===
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            Console.WriteLine($"[MEM-DIAG] XSSFSheet.Read: after InitRows (XSSFRow+XSSFCell wrappers created): {GC.GetTotalMemory(false):N0} bytes");
-            // === END ===
-
             InitColumns(worksheet);
 
             // Look for bits we're interested in

--- a/ooxml/XSSF/UserModel/XSSFSheet.cs
+++ b/ooxml/XSSF/UserModel/XSSFSheet.cs
@@ -35,6 +35,8 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
+using CT_Drawing = NPOI.OpenXmlFormats.Spreadsheet.CT_Drawing;
+using CT_LegacyDrawing = NPOI.OpenXmlFormats.Spreadsheet.CT_LegacyDrawing;
 using CT_Shape = NPOI.OpenXmlFormats.Vml.CT_Shape;
 using ST_EditAs = NPOI.OpenXmlFormats.Dml.Spreadsheet.ST_EditAs;
 
@@ -1248,21 +1250,76 @@ namespace NPOI.XSSF.UserModel
             {
                 throw new POIXMLException(e);
             }
+
+            // Release the decompressed ZIP entry data for this sheet.
+            // The data has been fully parsed into the CT_Worksheet object model
+            // and is no longer needed. This sheet's Commit() method will regenerate
+            // the XML from the object model during save.
+            // For a 10K-row sheet, this frees ~3.5MB of decompressed XML data.
+            if (GetPackagePart() is ZipPackagePart zipPart)
+            {
+                zipPart.ReleaseZipEntryData();
+            }
         }
+
+        /// <summary>
+        /// Threshold in bytes above which streaming XML parse is used for sheet data.
+        /// This avoids loading the full sheet XML into an XmlDocument DOM tree, which
+        /// can use 3-10x the raw XML size in memory for large sheets.
+        /// </summary>
+        private const long StreamingParseThreshold = 1 * 1024 * 1024; // 10MB
 
         internal virtual void Read(Stream is1)
         {
             try
             {
-                XmlDocument doc = ConvertStreamToXml(is1);
-                worksheet = WorksheetDocument.Parse(doc, NamespaceManager).GetWorksheet();
+                long streamLength = is1.CanSeek ? is1.Length : -1;
+
+                // === MEMORY DIAGNOSTIC ===
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Console.WriteLine($"[MEM-DIAG] XSSFSheet.Read START: stream={streamLength:N0} bytes, threshold={StreamingParseThreshold:N0}, mode={(streamLength > StreamingParseThreshold ? "STREAMING" : "DOM")}, mem={GC.GetTotalMemory(false):N0}");
+                // === END ===
+
+                if (streamLength > StreamingParseThreshold)
+                {
+                    ReadStreaming(is1);
+                }
+                else
+                {
+                    XmlDocument doc = ConvertStreamToXml(is1);
+                    // === MEMORY DIAGNOSTIC ===
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    Console.WriteLine($"[MEM-DIAG] XSSFSheet.Read: after ConvertStreamToXml (DOM built): {GC.GetTotalMemory(false):N0} bytes");
+                    // === END ===
+                    worksheet = WorksheetDocument.Parse(doc, NamespaceManager).GetWorksheet();
+                }
             }
             catch (XmlException e)
             {
                 throw new POIXMLException(e);
             }
 
+            // === MEMORY DIAGNOSTIC ===
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            int rowCount = worksheet?.sheetData?.SizeOfRowArray() ?? 0;
+            int cellCount = 0;
+            if (worksheet?.sheetData?.row != null)
+                foreach (var r in worksheet.sheetData.row)
+                    cellCount += r.SizeOfCArray();
+            Console.WriteLine($"[MEM-DIAG] XSSFSheet.Read: after parse, before InitRows: rows={rowCount}, cells={cellCount}, mem={GC.GetTotalMemory(false):N0} bytes");
+            // === END ===
+
             InitRows(worksheet);
+
+            // === MEMORY DIAGNOSTIC ===
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Console.WriteLine($"[MEM-DIAG] XSSFSheet.Read: after InitRows (XSSFRow+XSSFCell wrappers created): {GC.GetTotalMemory(false):N0} bytes");
+            // === END ===
+
             InitColumns(worksheet);
 
             // Look for bits we're interested in
@@ -1288,6 +1345,217 @@ namespace NPOI.XSSF.UserModel
 
             // Process external hyperlinks for the sheet, if there are any
             InitHyperlinks();
+        }
+
+        /// <summary>
+        /// Streaming parse for large sheets. Parses the sheetData section (rows and cells)
+        /// using XmlReader to avoid loading the full DOM tree into memory. Metadata sections
+        /// (sheetPr, dimension, sheetViews, etc.) are parsed as small DOM subtrees since they
+        /// are typically small.
+        /// </summary>
+        private void ReadStreaming(Stream is1)
+        {
+            worksheet = new CT_Worksheet();
+            worksheet.sheetData = new CT_SheetData();
+            worksheet.sheetData.row = new List<CT_Row>();
+            worksheet.cols = new List<CT_Cols>();
+            worksheet.conditionalFormatting = new List<CT_ConditionalFormatting>();
+
+            var readerSettings = new XmlReaderSettings
+            {
+                XmlResolver = null,
+#pragma warning disable CS0618
+                ProhibitDtd = true,
+#pragma warning restore CS0618
+                CloseInput = false
+            };
+
+            // Collect cols node XML to parse after sheetData (needs lastColumn info)
+            string colsOuterXml = null;
+
+            using (XmlReader reader = XmlReader.Create(is1, readerSettings))
+            {
+                // Use an explicit advance flag to avoid double-advancing after ReadOuterXml.
+                // ReadOuterXml() positions the reader on the next node, so calling Read()
+                // again would skip that node entirely.
+                bool needsRead = true;
+                while (needsRead ? reader.Read() : !reader.EOF)
+                {
+                    needsRead = true; // default: advance on next iteration
+
+                    if (reader.NodeType != XmlNodeType.Element)
+                        continue;
+
+                    switch (reader.LocalName)
+                    {
+                        case "sheetData":
+                            ParseSheetDataStreaming(reader);
+                            needsRead = false; // ParseSheetDataStreaming leaves reader on next node
+                            break;
+                        case "cols":
+                            colsOuterXml = reader.ReadOuterXml();
+                            needsRead = false; // ReadOuterXml already advanced
+                            break;
+                        case "sheetPr":
+                            worksheet.sheetPr = ParseSubtreeElement<CT_SheetPr>(reader, CT_SheetPr.Parse);
+                            needsRead = false;
+                            break;
+                        case "dimension":
+                            worksheet.dimension = ParseSubtreeElement<CT_SheetDimension>(reader, CT_SheetDimension.Parse);
+                            needsRead = false;
+                            break;
+                        case "sheetViews":
+                            worksheet.sheetViews = ParseSubtreeElement<CT_SheetViews>(reader, CT_SheetViews.Parse);
+                            needsRead = false;
+                            break;
+                        case "sheetFormatPr":
+                            worksheet.sheetFormatPr = ParseSubtreeElement<CT_SheetFormatPr>(reader, CT_SheetFormatPr.Parse);
+                            needsRead = false;
+                            break;
+                        case "mergeCells":
+                            worksheet.mergeCells = ParseSubtreeElement<CT_MergeCells>(reader, CT_MergeCells.Parse);
+                            needsRead = false;
+                            break;
+                        case "hyperlinks":
+                            worksheet.hyperlinks = ParseSubtreeElement<CT_Hyperlinks>(reader, CT_Hyperlinks.Parse);
+                            needsRead = false;
+                            break;
+                        case "pageMargins":
+                            worksheet.pageMargins = ParseSubtreeElement<CT_PageMargins>(reader, CT_PageMargins.Parse);
+                            needsRead = false;
+                            break;
+                        case "pageSetup":
+                            worksheet.pageSetup = ParseSubtreeElement<CT_PageSetup>(reader, CT_PageSetup.Parse);
+                            needsRead = false;
+                            break;
+                        case "headerFooter":
+                            worksheet.headerFooter = ParseSubtreeElement<CT_HeaderFooter>(reader, CT_HeaderFooter.Parse);
+                            needsRead = false;
+                            break;
+                        case "printOptions":
+                            worksheet.printOptions = ParseSubtreeElement<CT_PrintOptions>(reader, CT_PrintOptions.Parse);
+                            needsRead = false;
+                            break;
+                        case "sheetProtection":
+                            worksheet.sheetProtection = ParseSubtreeElement<CT_SheetProtection>(reader, CT_SheetProtection.Parse);
+                            needsRead = false;
+                            break;
+                        case "autoFilter":
+                            worksheet.autoFilter = ParseSubtreeElement<CT_AutoFilter>(reader, CT_AutoFilter.Parse);
+                            needsRead = false;
+                            break;
+                        case "dataValidations":
+                            worksheet.dataValidations = ParseSubtreeElement<CT_DataValidations>(reader, CT_DataValidations.Parse);
+                            needsRead = false;
+                            break;
+                        case "drawing":
+                            worksheet.drawing = ParseSubtreeElement<CT_Drawing>(reader, CT_Drawing.Parse);
+                            needsRead = false;
+                            break;
+                        case "legacyDrawing":
+                            worksheet.legacyDrawing = ParseSubtreeElement<CT_LegacyDrawing>(reader, CT_LegacyDrawing.Parse);
+                            needsRead = false;
+                            break;
+                        case "tableParts":
+                            worksheet.tableParts = ParseSubtreeElement<CT_TableParts>(reader, CT_TableParts.Parse);
+                            needsRead = false;
+                            break;
+                        case "conditionalFormatting":
+                            var cf = ParseSubtreeElement<CT_ConditionalFormatting>(reader, CT_ConditionalFormatting.Parse);
+                            if (cf != null)
+                                worksheet.conditionalFormatting.Add(cf);
+                            needsRead = false;
+                            break;
+                        case "rowBreaks":
+                            worksheet.rowBreaks = ParseSubtreeElement<CT_PageBreak>(reader, CT_PageBreak.Parse);
+                            needsRead = false;
+                            break;
+                        case "colBreaks":
+                            worksheet.colBreaks = ParseSubtreeElement<CT_PageBreak>(reader, CT_PageBreak.Parse);
+                            needsRead = false;
+                            break;
+                        case "extLst":
+                            worksheet.extLst = ParseSubtreeElement<CT_ExtensionList>(reader, CT_ExtensionList.Parse);
+                            needsRead = false;
+                            break;
+                        case "sortState":
+                            worksheet.sortState = ParseSubtreeElement<CT_SortState>(reader, CT_SortState.Parse);
+                            needsRead = false;
+                            break;
+                        case "phoneticPr":
+                            worksheet.phoneticPr = ParseSubtreeElement<CT_PhoneticPr>(reader, CT_PhoneticPr.Parse);
+                            needsRead = false;
+                            break;
+                        case "worksheet":
+                            // Root element - just let the loop advance into its children
+                            break;
+                        default:
+                            // Unknown element - skip it entirely (advances reader past it)
+                            reader.Skip();
+                            needsRead = false;
+                            break;
+                    }
+                }
+            }
+
+            // Parse cols after sheetData so we have lastColumn information
+            if (colsOuterXml != null)
+            {
+                XmlDocument colsDoc = new XmlDocument();
+                colsDoc.LoadXml(colsOuterXml);
+                worksheet.cols.Add(CT_Cols.Parse(colsDoc.DocumentElement, NamespaceManager, worksheet.sheetData.lastColumn));
+            }
+        }
+
+        /// <summary>
+        /// Helper to parse a small XML element subtree from an XmlReader into a typed object.
+        /// The element is read as outer XML, loaded into a small XmlDocument, then parsed
+        /// using the provided parse function.
+        /// </summary>
+        private T ParseSubtreeElement<T>(XmlReader reader, Func<XmlNode, XmlNamespaceManager, T> parseFunc)
+        {
+            string outerXml = reader.ReadOuterXml();
+            if (string.IsNullOrEmpty(outerXml)) return default(T);
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(outerXml);
+            return parseFunc(doc.DocumentElement, NamespaceManager);
+        }
+
+        /// <summary>
+        /// Parses the &lt;sheetData&gt; section using streaming XmlReader.
+        /// Each &lt;row&gt; element is read as a small DOM subtree and parsed into a CT_Row
+        /// using the existing CT_Row.Parse method, avoiding the need to hold the full
+        /// sheet XML DOM in memory.
+        /// </summary>
+        private void ParseSheetDataStreaming(XmlReader reader)
+        {
+            // reader is positioned on <sheetData>
+            if (reader.IsEmptyElement) return;
+
+            int sheetDataDepth = reader.Depth;
+
+            // Reuse one XmlDocument across all rows to reduce GC pressure
+            XmlDocument rowDoc = new XmlDocument();
+
+            bool needsRead = true;
+            while (needsRead ? reader.Read() : !reader.EOF)
+            {
+                needsRead = true;
+
+                if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == sheetDataDepth)
+                    break; // End of </sheetData>
+
+                if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "row")
+                {
+                    // Read the <row> subtree as a small DOM for CT_Row.Parse
+                    rowDoc.RemoveAll();
+                    rowDoc.LoadXml(reader.ReadOuterXml());
+                    CT_Row row = CT_Row.Parse(rowDoc.DocumentElement, NamespaceManager);
+                    worksheet.sheetData.row.Add(row);
+                    worksheet.sheetData.UpdateLastColumn(row.lastCell);
+                    needsRead = false; // ReadOuterXml already advanced
+                }
+            }
         }
 
         /// <summary>
@@ -1501,11 +1769,6 @@ namespace NPOI.XSSF.UserModel
                 }
 
                 worksheet.hyperlinks.SetHyperlinkArray(ctHls);
-            }
-
-            foreach (XSSFRow row in _rows.Values)
-            {
-                row.OnDocumentWrite();
             }
 
             int minCell = int.MaxValue, maxCell = int.MinValue;
@@ -3551,7 +3814,7 @@ namespace NPOI.XSSF.UserModel
                 }
             }
 
-            string ref1 = ((XSSFCell)cell).GetCTCell().r;
+            string ref1 = ((XSSFCell)cell).GetReference();
             throw new ArgumentException(
                 "Cell " + ref1 + " is not part of an array formula.");
         }

--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -203,27 +203,10 @@ namespace NPOI.XSSF.UserModel
         public XSSFWorkbook(OPCPackage pkg)
             : base(pkg)
         {
-            // === MEMORY DIAGNOSTIC ===
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            Console.WriteLine($"[MEM-DIAG] XSSFWorkbook ctor: before BeforeDocumentRead: {GC.GetTotalMemory(false):N0} bytes");
-            // === END ===
             BeforeDocumentRead();
-
-            // === MEMORY DIAGNOSTIC ===
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            Console.WriteLine($"[MEM-DIAG] XSSFWorkbook ctor: before Load(factory): {GC.GetTotalMemory(false):N0} bytes");
-            // === END ===
 
             //build a tree of POIXMLDocumentParts, this workbook being the root
             Load(XSSFFactory.GetInstance());
-
-            // === MEMORY DIAGNOSTIC ===
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            Console.WriteLine($"[MEM-DIAG] XSSFWorkbook ctor: after Load(factory): {GC.GetTotalMemory(false):N0} bytes");
-            // === END ===
 
             // some broken Workbooks miss this...
             if (!workbook.IsSetBookViews())
@@ -346,12 +329,6 @@ namespace NPOI.XSSF.UserModel
                 doc = WorkbookDocument.Parse(xmldoc, NamespaceManager);
                 this.workbook = doc.Workbook;
 
-                // === MEMORY DIAGNOSTIC ===
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Console.WriteLine($"[MEM-DIAG] OnDocumentRead: after parsing workbook.xml, before relation parts: {GC.GetTotalMemory(false):N0} bytes");
-                // === END ===
-
                 ThemesTable theme = null;
                 Dictionary<String, XSSFSheet> shIdMap = new Dictionary<String, XSSFSheet>();
                 Dictionary<String, ExternalLinksTable> elIdMap = new Dictionary<String, ExternalLinksTable>();
@@ -403,12 +380,6 @@ namespace NPOI.XSSF.UserModel
                     }
                 }
 
-                // === MEMORY DIAGNOSTIC ===
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Console.WriteLine($"[MEM-DIAG] OnDocumentRead: before ParseSheet loop ({shIdMap.Count} sheets): {GC.GetTotalMemory(false):N0} bytes");
-                // === END ===
-
                 // Load individual sheets. The order of sheets is defined by the order
                 //  of CTSheet elements in the workbook
                 sheets = new List<XSSFSheet>(shIdMap.Count);
@@ -417,12 +388,6 @@ namespace NPOI.XSSF.UserModel
                     ParseSheet(shIdMap, ctSheet);
 
                 }
-
-                // === MEMORY DIAGNOSTIC ===
-                GC.Collect();
-                GC.WaitForPendingFinalizers();
-                Console.WriteLine($"[MEM-DIAG] OnDocumentRead: after ParseSheet loop: {GC.GetTotalMemory(false):N0} bytes");
-                // === END ===
 
                 // Load the external links tables. Their order is defined by the order 
                 //  of CTExternalReference elements in the workbook

--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -203,10 +203,27 @@ namespace NPOI.XSSF.UserModel
         public XSSFWorkbook(OPCPackage pkg)
             : base(pkg)
         {
+            // === MEMORY DIAGNOSTIC ===
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Console.WriteLine($"[MEM-DIAG] XSSFWorkbook ctor: before BeforeDocumentRead: {GC.GetTotalMemory(false):N0} bytes");
+            // === END ===
             BeforeDocumentRead();
+
+            // === MEMORY DIAGNOSTIC ===
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Console.WriteLine($"[MEM-DIAG] XSSFWorkbook ctor: before Load(factory): {GC.GetTotalMemory(false):N0} bytes");
+            // === END ===
 
             //build a tree of POIXMLDocumentParts, this workbook being the root
             Load(XSSFFactory.GetInstance());
+
+            // === MEMORY DIAGNOSTIC ===
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            Console.WriteLine($"[MEM-DIAG] XSSFWorkbook ctor: after Load(factory): {GC.GetTotalMemory(false):N0} bytes");
+            // === END ===
 
             // some broken Workbooks miss this...
             if (!workbook.IsSetBookViews())
@@ -329,6 +346,12 @@ namespace NPOI.XSSF.UserModel
                 doc = WorkbookDocument.Parse(xmldoc, NamespaceManager);
                 this.workbook = doc.Workbook;
 
+                // === MEMORY DIAGNOSTIC ===
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Console.WriteLine($"[MEM-DIAG] OnDocumentRead: after parsing workbook.xml, before relation parts: {GC.GetTotalMemory(false):N0} bytes");
+                // === END ===
+
                 ThemesTable theme = null;
                 Dictionary<String, XSSFSheet> shIdMap = new Dictionary<String, XSSFSheet>();
                 Dictionary<String, ExternalLinksTable> elIdMap = new Dictionary<String, ExternalLinksTable>();
@@ -380,6 +403,12 @@ namespace NPOI.XSSF.UserModel
                     }
                 }
 
+                // === MEMORY DIAGNOSTIC ===
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Console.WriteLine($"[MEM-DIAG] OnDocumentRead: before ParseSheet loop ({shIdMap.Count} sheets): {GC.GetTotalMemory(false):N0} bytes");
+                // === END ===
+
                 // Load individual sheets. The order of sheets is defined by the order
                 //  of CTSheet elements in the workbook
                 sheets = new List<XSSFSheet>(shIdMap.Count);
@@ -388,6 +417,13 @@ namespace NPOI.XSSF.UserModel
                     ParseSheet(shIdMap, ctSheet);
 
                 }
+
+                // === MEMORY DIAGNOSTIC ===
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                Console.WriteLine($"[MEM-DIAG] OnDocumentRead: after ParseSheet loop: {GC.GetTotalMemory(false):N0} bytes");
+                // === END ===
+
                 // Load the external links tables. Their order is defined by the order 
                 //  of CTExternalReference elements in the workbook
                 externalLinks = new List<ExternalLinksTable>(elIdMap.Count);

--- a/ooxml/XSSF/UserModel/XSSFWorkbook.cs
+++ b/ooxml/XSSF/UserModel/XSSFWorkbook.cs
@@ -386,7 +386,6 @@ namespace NPOI.XSSF.UserModel
                 foreach (CT_Sheet ctSheet in this.workbook.sheets.sheet)
                 {
                     ParseSheet(shIdMap, ctSheet);
-
                 }
 
                 // Load the external links tables. Their order is defined by the order 

--- a/openxml4Net/OPC/Internal/MemoryPackagePart.cs
+++ b/openxml4Net/OPC/Internal/MemoryPackagePart.cs
@@ -58,12 +58,20 @@ namespace NPOI.OpenXml4Net.OPC.Internal
         protected override Stream GetInputStreamImpl()
         {
             // If this part has been created from scratch and/or the data buffer is
-            // not
-            // initialize, so we do it now.
+            // not initialized, return an empty stream.
             if (data == null)
             {
-                return new MemoryStream();
+                return new MemoryStream(Array.Empty<byte>(), writable: false);
             }
+
+            // Try to return a non-writable view of the data without copying.
+            // This avoids duplicating potentially large buffers in memory.
+            if (data.TryGetBuffer(out System.ArraySegment<byte> segment))
+            {
+                return new MemoryStream(segment.Array, segment.Offset, segment.Count, writable: false);
+            }
+
+            // Fallback: copy the data (original behavior)
             MemoryStream newMs = new MemoryStream((int)data.Length);
             data.Position = 0;
             StreamHelper.CopyStream(data, newMs);

--- a/openxml4Net/OPC/ZipPackage.cs
+++ b/openxml4Net/OPC/ZipPackage.cs
@@ -195,8 +195,8 @@ namespace NPOI.OpenXml4Net.OPC
             while (entries.MoveNext())
             {
                 ZipEntry entry = (ZipEntry)entries.Current;
-                if (entry.Name.ToLower().Equals(
-                        ContentTypeManager.CONTENT_TYPES_PART_NAME.ToLower()))
+                if (entry.Name.Equals(
+                        ContentTypeManager.CONTENT_TYPES_PART_NAME, StringComparison.OrdinalIgnoreCase))
                 {
                     try
                     {
@@ -324,8 +324,8 @@ namespace NPOI.OpenXml4Net.OPC
             {
                 // We get an error when we parse [Content_Types].xml
                 // because it's not a valid URI.
-                if (entry.Name.ToLower().Equals(
-                        ContentTypeManager.CONTENT_TYPES_PART_NAME.ToLower()))
+                if (entry.Name.Equals(
+                        ContentTypeManager.CONTENT_TYPES_PART_NAME, StringComparison.OrdinalIgnoreCase))
                 {
                     return null;
                 }

--- a/openxml4Net/OPC/ZipPackagePart.cs
+++ b/openxml4Net/OPC/ZipPackagePart.cs
@@ -1,9 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.IO;
+﻿using ICSharpCode.SharpZipLib.Zip;
 using NPOI.OpenXml4Net.OPC.Internal.Marshallers;
-using ICSharpCode.SharpZipLib.Zip;
+using NPOI.OpenXml4Net.Util;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
 
 namespace NPOI.OpenXml4Net.OPC
 {
@@ -120,6 +121,21 @@ public class ZipPackagePart : PackagePart {
     public override void Flush()
     {
         throw new InvalidOperationException("Method not implemented !");
+    }
+
+    /// <summary>
+    /// Releases the decompressed ZIP entry data backing this part.
+    /// Call after the part's content has been fully parsed into an object model.
+    /// This frees the in-memory byte[] held by ZipInputStreamZipEntrySource.FakeZipEntry.
+    /// After calling this, GetInputStream() will return an empty stream.
+    /// Only safe for parts that regenerate their content during save via Commit().
+    /// </summary>
+    public void ReleaseZipEntryData()
+    {
+        if (_container is ZipPackage zipPkg && zipPkg.ZipArchive is ZipInputStreamZipEntrySource source)
+        {
+            source.ReleaseEntryData(zipEntry);
+        }
     }
 }
 }

--- a/openxml4Net/Util/ZipInputStreamZipEntrySource.cs
+++ b/openxml4Net/Util/ZipInputStreamZipEntrySource.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
@@ -20,7 +20,7 @@ namespace NPOI.OpenXml4Net.Util
         private List<FakeZipEntry> zipEntries;
 
         /**
-         * Reads all the entries from the ZipInputStream 
+         * Reads all the entries from the ZipInputStream
          *  into memory, and closes the source stream.
          * We'll then eat lots of memory, but be able to
          *  work with the entries at-will.
@@ -29,23 +29,77 @@ namespace NPOI.OpenXml4Net.Util
         {
             zipEntries = new List<FakeZipEntry>();
 
-            bool going = true;
-            while (going)
+            // === MEMORY DIAGNOSTIC ===
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            long memStart = GC.GetTotalMemory(false);
+            Console.WriteLine($"[MEM-DIAG] ZipEntrySource: START decompressing ZIP entries, mem={memStart:N0}");
+            // === END ===
+
+            try
             {
-                ZipEntry zipEntry = inp.GetNextEntry();
-                if (zipEntry == null)
-                {
-                    going = false;
-                }
-                else
+                ZipEntry zipEntry;
+                while ((zipEntry = inp.GetNextEntry()) != null)
                 {
                     FakeZipEntry entry = new FakeZipEntry(zipEntry, inp);
-                    //inp.Close();
-
                     zipEntries.Add(entry);
+
+                    // === MEMORY DIAGNOSTIC ===
+                    Console.WriteLine($"[MEM-DIAG] ZipEntrySource: decompressed '{entry.Name}' size={entry.GetInputStream().Length:N0} bytes");
+                    // === END ===
                 }
             }
-            inp.Close();
+            catch
+            {
+                // On failure (e.g. OutOfMemoryException), release already-decompressed
+                // entries to reduce memory pressure before re-throwing
+                foreach (var entry in zipEntries)
+                {
+                    entry.ClearData();
+                }
+                zipEntries.Clear();
+                throw;
+            }
+            finally
+            {
+                inp.Close();
+            }
+
+            // === MEMORY DIAGNOSTIC ===
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            long memEnd = GC.GetTotalMemory(false);
+            Console.WriteLine($"[MEM-DIAG] ZipEntrySource: DONE, {zipEntries.Count} entries, total decompressed mem delta={memEnd - memStart:N0} bytes, mem={memEnd:N0}");
+            // === END ===
+        }
+
+        /// <summary>
+        /// Releases the decompressed byte[] data from all entries without closing the source.
+        /// Subsequent GetInputStream() calls will return empty streams.
+        /// Call this after all part data has been parsed into object models.
+        /// </summary>
+        public void ReleaseEntryData()
+        {
+            if (zipEntries == null)
+                return;
+            foreach (var entry in zipEntries)
+            {
+                entry.ClearData();
+            }
+        }
+
+        /// <summary>
+        /// Releases the decompressed byte[] data from a specific entry.
+        /// Call this after the entry's data has been fully parsed into an object model
+        /// and is no longer needed. Subsequent GetInputStream() calls for this entry
+        /// will return an empty stream.
+        /// </summary>
+        public void ReleaseEntryData(ZipEntry entry)
+        {
+            if (entry is FakeZipEntry fakeEntry)
+            {
+                fakeEntry.ClearData();
+            }
         }
 
         public IEnumerator Entries
@@ -64,8 +118,15 @@ namespace NPOI.OpenXml4Net.Util
 
         public void Close()
         {
-            // Free the memory
-            zipEntries = null;
+            if (zipEntries != null)
+            {
+                // Explicitly release data references to help GC
+                foreach (var entry in zipEntries)
+                {
+                    entry.ClearData();
+                }
+                zipEntries = null;
+            }
         }
 
         public bool IsClosed
@@ -113,18 +174,18 @@ namespace NPOI.OpenXml4Net.Util
          * So we can close the real zip entry and still
          *  effectively work with it.
          * Holds the (decompressed!) data in memory, so
-         *  close this as soon as you can! 
+         *  close this as soon as you can!
          */
         public class FakeZipEntry : ZipEntry
         {
             private byte[] data;
 
+            // Larger buffer size (80KB) for improved throughput on large entries,
+            // matching .NET's Stream.CopyTo default buffer size
+            private const int CopyBufferSize = 81920;
+
             public FakeZipEntry(ZipEntry entry, ZipInputStream inp) : base(entry.Name)
             {
-
-                // Grab the de-compressed contents for later
-                MemoryStream baos = new MemoryStream();
-
                 long entrySize = entry.Size;
 
                 if (entrySize != -1)
@@ -134,26 +195,66 @@ namespace NPOI.OpenXml4Net.Util
                         throw new IOException("ZIP entry size is too large");
                     }
 
-                    baos = new MemoryStream((int)entrySize);
+                    // Known size: allocate exact byte[] and read directly into it
+                    // This avoids the MemoryStream + ToArray() double-allocation
+                    data = new byte[(int)entrySize];
+                    int offset = 0;
+                    int remaining = data.Length;
+                    while (remaining > 0)
+                    {
+                        int read = inp.Read(data, offset, remaining);
+                        if (read <= 0) break;
+                        offset += read;
+                        remaining -= read;
+                    }
+
+                    // If we read fewer bytes than expected, trim the array
+                    if (remaining > 0)
+                    {
+                        Array.Resize(ref data, offset);
+                    }
                 }
                 else
                 {
-                    baos = new MemoryStream();
-                }
+                    // Unknown size: use MemoryStream, then try to avoid ToArray() copy
+                    MemoryStream baos = new MemoryStream();
+                    byte[] buffer = new byte[CopyBufferSize];
+                    int read;
+                    while ((read = inp.Read(buffer, 0, buffer.Length)) > 0)
+                    {
+                        baos.Write(buffer, 0, read);
+                    }
 
-                byte[] buffer = new byte[4096];
-                int read = 0;
-                while ((read = inp.Read(buffer, 0, buffer.Length)) > 0)
-                {
-                    baos.Write(buffer, 0, read);
+                    // Try to get the underlying buffer without copying
+                    if (baos.TryGetBuffer(out ArraySegment<byte> segment)
+                        && segment.Offset == 0
+                        && segment.Count == segment.Array.Length)
+                    {
+                        data = segment.Array;
+                    }
+                    else
+                    {
+                        data = baos.ToArray();
+                    }
                 }
-
-                data = baos.ToArray();
             }
 
             public Stream GetInputStream()
             {
-                return new MemoryStream(data);
+                if (data == null)
+                {
+                    return new MemoryStream(Array.Empty<byte>(), writable: false);
+                }
+                return new MemoryStream(data, writable: false);
+            }
+
+            /// <summary>
+            /// Releases the decompressed data held by this entry to free memory.
+            /// After calling this method, GetInputStream() will return an empty stream.
+            /// </summary>
+            public void ClearData()
+            {
+                data = null;
             }
         }
     }

--- a/openxml4Net/Util/ZipInputStreamZipEntrySource.cs
+++ b/openxml4Net/Util/ZipInputStreamZipEntrySource.cs
@@ -177,8 +177,22 @@ namespace NPOI.OpenXml4Net.Util
                         throw new IOException("ZIP entry size is too large");
                     }
 
-                    // Known size: allocate exact byte[] and read directly into it
-                    // This avoids the MemoryStream + ToArray() double-allocation
+                    // Known size: allocate exact byte[] and read directly into it.
+                    // This avoids the MemoryStream + ToArray() double-allocation that the
+                    // fallback path below performs.
+                    //
+                    // Trust contract: we trust ZipEntry.Size as reported by SharpZipLib's
+                    // ZIP central-directory parser. If a malformed entry produces *more*
+                    // decompressed bytes than its declared size, the read loop terminates
+                    // at remaining == 0 and any excess bytes are NOT consumed. This means
+                    // for malformed inputs:
+                    //   - the next entry boundary in the ZipInputStream may be misaligned
+                    //     (the next GetNextEntry() call may fail or return a corrupt entry),
+                    //   - the silently-discarded bytes are not surfaced to the caller.
+                    // For well-formed XLSX files written by Excel, NPOI, OpenOffice, etc.,
+                    // the declared size always matches the decompressed length, so this is
+                    // the correct trade-off (one allocation, no copy). The malformed-input
+                    // case is caught at a higher level when ZIP parsing fails.
                     data = new byte[(int)entrySize];
                     int offset = 0;
                     int remaining = data.Length;
@@ -190,7 +204,8 @@ namespace NPOI.OpenXml4Net.Util
                         remaining -= read;
                     }
 
-                    // If we read fewer bytes than expected, trim the array
+                    // If we read fewer bytes than expected (truncated entry), trim the
+                    // array so callers see only the bytes that were actually present.
                     if (remaining > 0)
                     {
                         Array.Resize(ref data, offset);

--- a/openxml4Net/Util/ZipInputStreamZipEntrySource.cs
+++ b/openxml4Net/Util/ZipInputStreamZipEntrySource.cs
@@ -29,13 +29,6 @@ namespace NPOI.OpenXml4Net.Util
         {
             zipEntries = new List<FakeZipEntry>();
 
-            // === MEMORY DIAGNOSTIC ===
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            long memStart = GC.GetTotalMemory(false);
-            Console.WriteLine($"[MEM-DIAG] ZipEntrySource: START decompressing ZIP entries, mem={memStart:N0}");
-            // === END ===
-
             try
             {
                 ZipEntry zipEntry;
@@ -43,10 +36,6 @@ namespace NPOI.OpenXml4Net.Util
                 {
                     FakeZipEntry entry = new FakeZipEntry(zipEntry, inp);
                     zipEntries.Add(entry);
-
-                    // === MEMORY DIAGNOSTIC ===
-                    Console.WriteLine($"[MEM-DIAG] ZipEntrySource: decompressed '{entry.Name}' size={entry.GetInputStream().Length:N0} bytes");
-                    // === END ===
                 }
             }
             catch
@@ -64,13 +53,6 @@ namespace NPOI.OpenXml4Net.Util
             {
                 inp.Close();
             }
-
-            // === MEMORY DIAGNOSTIC ===
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            long memEnd = GC.GetTotalMemory(false);
-            Console.WriteLine($"[MEM-DIAG] ZipEntrySource: DONE, {zipEntries.Count} entries, total decompressed mem delta={memEnd - memStart:N0} bytes, mem={memEnd:N0}");
-            // === END ===
         }
 
         /// <summary>


### PR DESCRIPTION
## NuGet Release Note
Reduced memory footprint when loading large XLSX files.

## Summary
Significantly reduces memory consumption when loading large XLSX files through the NPOI XSSF pipeline. Targeted at the scenario where IronXL on Linux containers with cgroup memory limits (~4GB) fails to load 20-63MB XLSX files due to excessive memory amplification during parsing.

## Description
### Problem

When loading XLSX files, NPOI's XSSF pipeline:

1. Eagerly decompressed every ZIP entry into a `byte[]` held for the workbook's lifetime.
2. Parsed each sheet's XML into a full `XmlDocument` DOM tree (3–10× the raw XML size).
3. Created redundant per-cell overhead (nullable boxing, cached references to workbook-level singletons, red-black tree nodes, transient `CellReference` objects).

For a 48MB XLSX with 11.4M cells, peak memory reached ~8GB — enough to OOM on 4GB Linux containers even when Windows had no issue.

### Changes

**Streaming XML Parse**

- `XSSFSheet.Read()` uses `XmlReader` for sheets larger than 1MB, parsing each `<row>` as an isolated micro-DOM rather than building a full `XmlDocument`.
- `SharedStringsTable.ReadFrom()` uses `XmlReader` for shared-strings tables larger than 1MB.
- Both streaming paths correctly handle the `ReadOuterXml()` advance semantics (using a `needsRead` flag to avoid the classic skip-every-other-element trap).
- `XmlDocument` instances are reused across iterations to reduce GC pressure.

**Release Decompressed ZIP Data After Parse**

- `ZipInputStreamZipEntrySource` exposes `ReleaseEntryData(ZipEntry)` and a `FakeZipEntry.ClearData()` to free decompressed byte arrays on demand.
- `ZipPackagePart.ReleaseZipEntryData()` allows any part to release its backing ZIP entry data.
- Called from `XSSFSheet.OnDocumentRead()`, `SharedStringsTable` constructor, `StylesTable` constructor, and `CalculationChain` constructor — parts that have `Commit()` overrides and regenerate their XML from the in-memory object model during save.

**Collection and Field Layout Optimizations**

- `XSSFRow._cells`: `SortedDictionary<int, ICell>` → `SortedList<int, ICell>`. Same sorted-iteration guarantee, ~44 bytes less per cell (flat arrays vs. tree nodes).
- `CT_Cell`: nullable `uint? / ST_CellType? / bool?` fields replaced with plain value-type fields. `tField` explicitly initialised to `ST_CellType.n` to match the original default (preventing blank cells from being treated as boolean).
- `XSSFCell`: `_sharedStringSource` and `_stylesSource` fields removed; accessed on-demand via `_row.Sheet.Workbook`. Saves 16 bytes per cell.
- `XSSFCell`: inline `ParseColumnIndex()` replaces `new CellReference(cell.r).Col`, eliminating a 48-byte allocation per cell.
- `CT_Row`: seven `bool` fields packed into a single `[Flags] byte`.
- `CT_Rst.Parse`: `r` and `rPh` lists lazily initialised only when elements are found.
- `CT_SheetData`: added `UpdateLastColumn()` to support streaming row parsing.
- Pre-sized lists/dictionaries where counts are known (`sst.si`, `shIdMap`, etc.).

**Zip / Packaging Improvements**

- `FakeZipEntry`: when the compressed entry size is known, read directly into an exact-sized `byte[]` rather than writing to a `MemoryStream` and then `ToArray()`-copying it (eliminates a transient full-size allocation).
- Copy buffer size increased from 4KB to 80KB.
- `MemoryPackagePart.GetInputStreamImpl()`: uses `TryGetBuffer()` to return a read-only view rather than copying the buffer.
- `ZipPackage`: `StringComparison.OrdinalIgnoreCase` instead of `ToLower()` allocations for content-type comparisons.

**Other**

- Removed a duplicate `OnDocumentWrite()` iteration in `XSSFSheet.Write()` (the second loop already did what the first loop did, plus more).
- On catastrophic failure during decompression, `ZipInputStreamZipEntrySource` clears already-decompressed entries before rethrowing, to avoid compounding memory pressure during OOM.

## How this has been tested

**Unit tests (all existing NPOI test cases)**

All existing XSSF / OPC tests pass locally and in CI across Windows, Linux, and macOS.

The streaming parse paths share the same `CT_Row.Parse` and `CT_Rst.Parse` routines as the DOM path; they were validated to produce byte-identical object models through round-trip tests on:

- Files with missing `r` attributes (`TestMissingRAttributeBug54288`).
- Files with merged cells, hyperlinks, conditional formatting, data validation, auto-filters, column widths, frozen panes, sheet protection, print setup, and drawings.
- Password-protected XLSX files (encrypt → re-load → decrypt round-trip).
- Workbooks with shared formulas and array formulas.
- XLS (HSSF) and CSV/TSV paths (unchanged; regression-checked).

**Memory / performance tests**

A dedicated `LargeFileMemoryTests` suite was added on the IronXL side to validate:

- Roundtrip correctness on large files (5K, 10K, and multi-sheet workbooks).
- Memory ratio stays within a reasonable bound.
- Corrupted XLSX produces a clear error mentioning "XLSX" (not a misleading CSV fallback message).
- Shared-string preservation across the streaming parse.
- Save-after-load produces valid XLSX (`Write` path still emits correct cell references via `OnDocumentWrite`).

**Manual validation with customer-representative file**

A production-representative 48MB XLSX (2 sheets × 100K+ rows × ~100 columns, 11.4M cells) was loaded repeatedly on Linux and Windows. Peak managed heap measured via `GC.GetTotalMemory(false)` between diagnostic checkpoints:

Earlier pre-optimisation baseline was ~8 GB for the same file.