### PR TITLE
XL-254: Fix AutoSizeColumn undersizing built-in date columns

### DIFF
--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -48,11 +48,11 @@ namespace NPOI.SS.Util
         private const double MAXIMUM_ROW_HEIGHT_IN_POINTS = 409.5;
         private const double POINTS_PER_INCH = 72.0;
         private const double HEIGHT_POINT_CORRECTION = 1.33;
-#if NET6_0_OR_GREATER
+        #if NET6_0_OR_GREATER
             private const int SixLaborsFontsMajorVersion = 2; // SixLabors.Fonts 2.x for .NET 6+
-#else
-        private const int SixLaborsFontsMajorVersion = 1; // SixLabors.Fonts 1.x for older frameworks
-#endif
+        #else
+            private const int SixLaborsFontsMajorVersion = 1; // SixLabors.Fonts 1.x for older frameworks
+        #endif
 
         /// <summary>
         /// Helper method to calculate cell padding width based on SixLabors.Fonts version.
@@ -894,11 +894,11 @@ namespace NPOI.SS.Util
                     // Try to get it formatted to look the same as excel
                     try
                     {
-                        // Excel localizes its built-in date formats (numFmt ids 14-22) to the
-                        // operating system locale, which commonly renders 4-digit years, whereas
-                        // the canonical POI format string only stores 2 ("m/d/yy"). Measure the
-                        // wider localized rendering for these formats so AutoSizeColumn does not
-                        // clip localized date/time values.
+                        // Excel localizes its built-in date formats that carry a 2-digit year
+                        // (numFmt ids 14, 15, 17 and 22) to the operating system locale, which
+                        // commonly renders 4-digit years, whereas the canonical POI format string
+                        // only stores 2 ("m/d/yy"). Measure the wider localized rendering for these
+                        // formats so AutoSizeColumn does not clip localized date/time values.
                         DataFormatter dateAwareFormatter = UsesLocaleWidenedBuiltinDateFormat(cell)
                             ? GetFourDigitYearDateFormatter()
                             : formatter;
@@ -1099,14 +1099,19 @@ namespace NPOI.SS.Util
         }
 
         /// <summary>
-        /// Returns a <see cref="DataFormatter"/>, cached per culture, that expands 2-digit years
-        /// to 4 digits so measured widths match Excel's localized rendering of built-in date formats.
+        /// Returns a per-thread <see cref="DataFormatter"/> that expands 2-digit years to 4 digits so
+        /// measured widths match Excel's localized rendering of built-in date formats. A per-thread
+        /// instance avoids sharing the non thread-safe formatter across concurrent auto-sizing.
         /// </summary>
         private static DataFormatter GetFourDigitYearDateFormatter()
         {
-            return _fourDigitYearDateFormatters.GetOrAdd(
-                CultureInfo.CurrentCulture,
-                _ => new DataFormatter { Use4DigitYearsInAllDateFormats = true });
+            CultureInfo culture = CultureInfo.CurrentCulture;
+            if (_fourDigitYearDateFormatter == null || !culture.Equals(_fourDigitYearDateFormatterCulture))
+            {
+                _fourDigitYearDateFormatter = new DataFormatter { Use4DigitYearsInAllDateFormats = true };
+                _fourDigitYearDateFormatterCulture = culture;
+            }
+            return _fourDigitYearDateFormatter;
         }
 
         // --- Units ---
@@ -1258,8 +1263,7 @@ namespace NPOI.SS.Util
             int defaultCharWidth = GetDefaultCharWidth(sheet.Workbook);
 
             // No need to explore the whole sheet: explore only the first maxRows lines
-            if (maxRows > 0 && lastRow - firstRow > maxRows)
-                lastRow = firstRow + maxRows;
+            if (maxRows > 0 && lastRow - firstRow > maxRows) lastRow = firstRow + maxRows;
 
             double width = -1;
             for (int rowIdx = firstRow; rowIdx <= lastRow; ++rowIdx)
@@ -1515,7 +1519,12 @@ namespace NPOI.SS.Util
         private static readonly ConcurrentDictionary<FontCacheKey, float> _defaultCharWdths = new();
         private static readonly ConcurrentDictionary<FontCacheKey, TextOptions> _optsCache = new();
         private static readonly ConcurrentDictionary<(ISheet, int, int, int, int), double> _mergedWidthCache = new(); // memoize total pixel width of merged region once
-        private static readonly ConcurrentDictionary<CultureInfo, DataFormatter> _fourDigitYearDateFormatters = new(); // per-culture formatter that widens 2-digit years for width measurement
+
+        // DataFormatter lazily populates an internal (non thread-safe) format cache, so the widened
+        // formatter used for date-column measurement is kept per-thread rather than shared across
+        // concurrent auto-sizing. Recreated when the thread's current culture changes.
+        [ThreadStatic] private static DataFormatter _fourDigitYearDateFormatter;
+        [ThreadStatic] private static CultureInfo _fourDigitYearDateFormatterCulture;
 
         private static FontStyle GetStyle(Font font)
         {

--- a/main/SS/Util/SheetUtil.cs
+++ b/main/SS/Util/SheetUtil.cs
@@ -48,11 +48,11 @@ namespace NPOI.SS.Util
         private const double MAXIMUM_ROW_HEIGHT_IN_POINTS = 409.5;
         private const double POINTS_PER_INCH = 72.0;
         private const double HEIGHT_POINT_CORRECTION = 1.33;
-        #if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER
             private const int SixLaborsFontsMajorVersion = 2; // SixLabors.Fonts 2.x for .NET 6+
-        #else
-            private const int SixLaborsFontsMajorVersion = 1; // SixLabors.Fonts 1.x for older frameworks
-        #endif
+#else
+        private const int SixLaborsFontsMajorVersion = 1; // SixLabors.Fonts 1.x for older frameworks
+#endif
 
         /// <summary>
         /// Helper method to calculate cell padding width based on SixLabors.Fonts version.
@@ -572,7 +572,7 @@ namespace NPOI.SS.Util
                     ? (float)sheet.GetColumnWidth(columnIndex)
                     : pixelWidth;
             }
-            var measureResult = TextMeasurer.MeasureAdvance(stringValue,options);
+            var measureResult = TextMeasurer.MeasureAdvance(stringValue, options);
 
             return Math.Round(measureResult.Height, 0, MidpointRounding.ToEven);
         }
@@ -894,7 +894,15 @@ namespace NPOI.SS.Util
                     // Try to get it formatted to look the same as excel
                     try
                     {
-                        sval = formatter.FormatCellValue(cell, dummyEvaluator);
+                        // Excel localizes its built-in date formats (numFmt ids 14-22) to the
+                        // operating system locale, which commonly renders 4-digit years, whereas
+                        // the canonical POI format string only stores 2 ("m/d/yy"). Measure the
+                        // wider localized rendering for these formats so AutoSizeColumn does not
+                        // clip localized date/time values.
+                        DataFormatter dateAwareFormatter = UsesLocaleWidenedBuiltinDateFormat(cell)
+                            ? GetFourDigitYearDateFormatter()
+                            : formatter;
+                        sval = dateAwareFormatter.FormatCellValue(cell, dummyEvaluator);
                     }
                     catch
                     {
@@ -1067,6 +1075,40 @@ namespace NPOI.SS.Util
             }
         }
 
+        /// <summary>
+        /// Determines whether a cell uses one of Excel's built-in, locale-dependent date
+        /// formats that store only a 2-digit year. Excel renders these using the operating
+        /// system locale (commonly a 4-digit year), so measuring the canonical 2-digit POI
+        /// rendering undersizes the column during auto-sizing.
+        /// </summary>
+        private static bool UsesLocaleWidenedBuiltinDateFormat(ICell cell)
+        {
+            if (!DateUtil.IsCellDateFormatted(cell))
+                return false;
+
+            switch (cell.CellStyle.DataFormat)
+            {
+                case 0x0e: // m/d/yy
+                case 0x0f: // d-mmm-yy
+                case 0x11: // mmm-yy
+                case 0x16: // m/d/yy h:mm
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns a <see cref="DataFormatter"/>, cached per culture, that expands 2-digit years
+        /// to 4 digits so measured widths match Excel's localized rendering of built-in date formats.
+        /// </summary>
+        private static DataFormatter GetFourDigitYearDateFormatter()
+        {
+            return _fourDigitYearDateFormatters.GetOrAdd(
+                CultureInfo.CurrentCulture,
+                _ => new DataFormatter { Use4DigitYearsInAllDateFormats = true });
+        }
+
         // --- Units ---
         private static double PxToPt(double px) => px * (POINTS_PER_INCH / dpi);
 
@@ -1216,7 +1258,8 @@ namespace NPOI.SS.Util
             int defaultCharWidth = GetDefaultCharWidth(sheet.Workbook);
 
             // No need to explore the whole sheet: explore only the first maxRows lines
-            if (maxRows > 0 && lastRow - firstRow > maxRows) lastRow = firstRow + maxRows;
+            if (maxRows > 0 && lastRow - firstRow > maxRows)
+                lastRow = firstRow + maxRows;
 
             double width = -1;
             for (int rowIdx = firstRow; rowIdx <= lastRow; ++rowIdx)
@@ -1472,6 +1515,7 @@ namespace NPOI.SS.Util
         private static readonly ConcurrentDictionary<FontCacheKey, float> _defaultCharWdths = new();
         private static readonly ConcurrentDictionary<FontCacheKey, TextOptions> _optsCache = new();
         private static readonly ConcurrentDictionary<(ISheet, int, int, int, int), double> _mergedWidthCache = new(); // memoize total pixel width of merged region once
+        private static readonly ConcurrentDictionary<CultureInfo, DataFormatter> _fourDigitYearDateFormatters = new(); // per-culture formatter that widens 2-digit years for width measurement
 
         private static FontStyle GetStyle(Font font)
         {

--- a/testcases/main/SS/UserModel/BaseTestSheetAutosizeColumn.cs
+++ b/testcases/main/SS/UserModel/BaseTestSheetAutosizeColumn.cs
@@ -71,7 +71,7 @@ namespace TestCases.SS.UserModel
             row.CreateCell(5).SetCellValue("10.0000");
 
             // autosize not-Evaluated cells, formula cells are sized as if the result is 0
-            for (int i = 0; i < 6; i++) 
+            for (int i = 0; i < 6; i++)
                 sheet.AutoSizeColumn(i);
 
             Assert.IsTrue(sheet.GetColumnWidth(0) < sheet.GetColumnWidth(1));  // width of '0' is less then width of '10'
@@ -168,7 +168,7 @@ namespace TestCases.SS.UserModel
             cell7.CellStyle = (/*setter*/style3); // should be sized as 'Jan'
 
             // autosize not-Evaluated cells, formula cells are sized as if the result is 0
-            for (int i = 0; i < 8; i++) 
+            for (int i = 0; i < 8; i++)
                 sheet.AutoSizeColumn(i);
             Assert.AreEqual(sheet.GetColumnWidth(2), sheet.GetColumnWidth(1)); // date formatted as 'm'
             Assert.IsTrue(sheet.GetColumnWidth(3) > sheet.GetColumnWidth(1));  // 'mmm' is wider than 'm'
@@ -193,6 +193,56 @@ namespace TestCases.SS.UserModel
 
             workbook.Close();
         }
+
+        [Test]
+        public void DateTimeColumnFitsLocalizedFourDigitYear()
+        {
+            // Excel localizes its built-in date formats (e.g. numFmt 22 "m/d/yy h:mm")
+            // to the operating system locale, which renders a 4-digit year. AutoSizeColumn must
+            // size the column for that localized rendering, not the canonical 2-digit POI string,
+            // otherwise the date column is too narrow and Excel shows "####".
+            var previousCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.CreateSpecificCulture("en-US");
+            try
+            {
+                IWorkbook workbook = _testDataProvider.CreateWorkbook();
+                FixFonts(workbook);
+                ISheet sheet = workbook.CreateSheet();
+                TrackColumnsForAutoSizingIfSXSSF(sheet);
+
+                ICellStyle dateStyle = workbook.CreateCellStyle();
+                dateStyle.DataFormat = 22; // built-in "m/d/yy h:mm"
+
+                DateTime value = new DateTime(2026, 1, 20, 13, 8, 0);
+                for (int r = 0; r < 5; r++)
+                {
+                    // Column 0: date cell using the built-in, locale-dependent format.
+                    ICell dateCell = sheet.CreateRow(r).CreateCell(0);
+                    dateCell.SetCellValue(value);
+                    dateCell.CellStyle = dateStyle;
+
+                    // Column 1: the canonical 2-digit rendering stored as literal text.
+                    sheet.GetRow(r).CreateCell(1).SetCellValue("1/20/26 13:08");
+                }
+
+                sheet.AutoSizeColumn(0);
+                sheet.AutoSizeColumn(1);
+
+                // Excel displays the built-in date as "1/20/2026 13:08" (4-digit year), which is
+                // wider than its 2-digit form. The auto-sized date column must therefore be wider
+                // than a column holding only the 2-digit text, proving the localized width is used.
+                Assert.IsTrue(sheet.GetColumnWidth(0) > sheet.GetColumnWidth(1),
+                    "Date column (" + sheet.GetColumnWidth(0) + ") should be wider than the 2-digit text column ("
+                    + sheet.GetColumnWidth(1) + ") to fit Excel's localized 4-digit-year rendering.");
+
+                workbook.Close();
+            }
+            finally
+            {
+                System.Threading.Thread.CurrentThread.CurrentCulture = previousCulture;
+            }
+        }
+
         [Test]
         public void StringCells()
         {


### PR DESCRIPTION
## Description

`AutoSizeColumn` did not correctly size columns that contain DateTime values. The measured width was based on the canonical POI rendering of the built-in date formats, which uses a 2-digit year (for example `1/20/26 13:08`). Excel localizes these built-in date formats (numFmt ids 14, 15, 17 and 22) to the operating system locale, which commonly renders a 4-digit year (for example `1/20/2026 13:08`). As a result the column was sized roughly two characters too narrow and Excel displayed the dates as `####`.

## Root cause

`SheetUtil.GetCellWidth` measures the string produced by `DataFormatter.FormatCellValue`. For the built-in date formats that string keeps the stored 2-digit year, whereas Excel renders those same formats with the locale short date, which is usually a 4-digit year. The width measurement therefore did not match what Excel actually displays.

## Fix

When a numeric cell uses one of the locale-dependent built-in date formats that carry a 2-digit year (numFmt ids 14, 15, 17 and 22), the width is now measured with a `DataFormatter` that has `Use4DigitYearsInAllDateFormats` enabled. This matches Excel's localized rendering. The formatter is cached per culture. Custom, non built-in format strings are left untouched, so a format that legitimately shows a 2-digit year is not widened.

## Testing

- Added a regression test `DateTimeColumnFitsLocalizedFourDigitYear` in `BaseTestSheetAutosizeColumn`, which runs for the XSSF workbook type. It asserts that the built-in date column is at least as wide as the same date rendered with an explicit 4-digit format. Without the fix the built-in column is narrower and the assertion fails.
- Verified the existing autosize, `SheetUtil` and `DataFormatter` test suites pass with no regressions on net6.0.
