### PR TITLE
XL-263: Add forward-only streaming XLSX reader (POI-style SAX API)

### DIFF
--- a/main/SS/UserModel/DataFormatter.cs
+++ b/main/SS/UserModel/DataFormatter.cs
@@ -982,7 +982,13 @@ namespace NPOI.SS.UserModel
             }
             else
             {
-                result = numberFormat.Format(decimal.Parse(textValue));
+                // NumberToTextConverter.ToText() always renders with '.' as the decimal point
+                // (it builds the digits manually, independent of any locale), so it must be
+                // parsed back with InvariantCulture. Parsing with the ambient thread culture
+                // (the previous behavior) corrupts the value under cultures where '.' is a
+                // group separator instead of a decimal point (e.g. de-DE turns "12.5" into 125)
+                // or where NumberStyles.Number rejects '.' outright (e.g. fr-FR throws FormatException).
+                result = numberFormat.Format(decimal.Parse(textValue, CultureInfo.InvariantCulture));
             }
             // Complete scientific notation by adding the missing +.
             if (result.Contains("E") && !result.Contains("E-"))

--- a/ooxml/XSSF/EventUserModel/SheetContentsHandler.cs
+++ b/ooxml/XSSF/EventUserModel/SheetContentsHandler.cs
@@ -1,0 +1,20 @@
+namespace NPOI.XSSF.EventUserModel
+{
+    /// <summary>Classifies a streamed cell's resolved value.</summary>
+    public enum StreamValueKind
+    {
+        Blank, Number, String, Boolean, Date, Formula, Error
+    }
+
+    /// <summary>
+    /// Callback surface for a single-sheet streaming parse. Mirrors Apache POI's
+    /// XSSFSheetXMLHandler.SheetContentsHandler, extended to carry the raw typed value.
+    /// </summary>
+    public interface SheetContentsHandler
+    {
+        void StartRow(int rowNum);
+        void EndRow(int rowNum);
+        void Cell(string cellReference, string formattedValue, object rawValue, StreamValueKind kind);
+        void HeaderFooter(string text, bool isHeader, string tagName);
+    }
+}

--- a/ooxml/XSSF/EventUserModel/XSSFReader.cs
+++ b/ooxml/XSSF/EventUserModel/XSSFReader.cs
@@ -1,0 +1,129 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml;
+using NPOI.OpenXml4Net.OPC;
+using NPOI.XSSF.Model;
+using NPOI.XSSF.UserModel;
+
+namespace NPOI.XSSF.EventUserModel
+{
+    /// <summary>
+    /// Read-side entry point for streaming XLSX parsing. Opens an OPCPackage and
+    /// exposes the styles table, shared strings, and per-sheet XML part streams
+    /// without constructing an XSSFWorkbook DOM.
+    /// </summary>
+    public class XSSFReader
+    {
+        public sealed class SheetRef
+        {
+            public string Name { get; internal set; }
+            public int Index { get; internal set; }
+            internal PackagePart Part { get; set; }
+        }
+
+        private readonly OPCPackage _pkg;
+        private readonly PackagePart _workbookPart;
+        private readonly List<SheetRef> _sheets = new List<SheetRef>();
+        private StylesTable _styles;
+        private ReadOnlySharedStringsTable _sst;
+
+        public XSSFReader(OPCPackage pkg)
+        {
+            _pkg = pkg ?? throw new ArgumentNullException(nameof(pkg));
+            List<PackagePart> wbParts = pkg.GetPartsByContentType(XSSFRelation.WORKBOOK.ContentType);
+            if (wbParts.Count == 0)
+            {
+                // Some producers use the macro/template content type.
+                wbParts = pkg.GetPartsByContentType(XSSFRelation.MACROS_WORKBOOK.ContentType);
+            }
+            if (wbParts.Count == 0)
+            {
+                throw new ArgumentException("Package does not contain a workbook part (is this a valid .xlsx?).");
+            }
+            _workbookPart = wbParts[0];
+            LoadSheetRefs();
+        }
+
+        public StylesTable GetStylesTable()
+        {
+            if (_styles == null)
+            {
+                List<PackagePart> parts = _pkg.GetPartsByContentType(XSSFRelation.STYLES.ContentType);
+                _styles = parts.Count > 0 ? new StylesTable(parts[0]) : new StylesTable();
+            }
+            return _styles;
+        }
+
+        public ReadOnlySharedStringsTable GetSharedStringsTable()
+        {
+            return _sst ?? (_sst = new ReadOnlySharedStringsTable(_pkg));
+        }
+
+        public IReadOnlyList<SheetRef> GetSheets() => _sheets;
+
+        public Stream GetSheetStream(int index)
+        {
+            if (index < 0 || index >= _sheets.Count)
+            {
+                throw new ArgumentException($"Sheet index {index} is out of range (0..{_sheets.Count - 1}).");
+            }
+            return _sheets[index].Part.GetInputStream();
+        }
+
+        public Stream GetSheetStream(string name)
+        {
+            foreach (SheetRef s in _sheets)
+            {
+                if (string.Equals(s.Name, name, StringComparison.Ordinal))
+                {
+                    return s.Part.GetInputStream();
+                }
+            }
+            throw new ArgumentException($"Sheet '{name}' was not found.");
+        }
+
+        private void LoadSheetRefs()
+        {
+            const string relNs = "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+            using (Stream wb = _workbookPart.GetInputStream())
+            using (XmlReader reader = XmlReader.Create(wb, new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit }))
+            {
+                int index = 0;
+                while (reader.Read())
+                {
+                    if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "sheet")
+                    {
+                        string name = reader.GetAttribute("name");
+                        string rid = reader.GetAttribute("id", relNs);
+                        PackageRelationship rel = _workbookPart.GetRelationship(rid);
+                        PackagePart part = _workbookPart.GetRelatedPart(rel);
+                        _sheets.Add(new SheetRef
+                        {
+                            Name = name,
+                            Index = index++,
+                            Part = part,
+                        });
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ooxml/XSSF/EventUserModel/XSSFReader.cs
+++ b/ooxml/XSSF/EventUserModel/XSSFReader.cs
@@ -77,7 +77,7 @@ namespace NPOI.XSSF.EventUserModel
             return _sst ?? (_sst = new ReadOnlySharedStringsTable(_pkg));
         }
 
-        public IReadOnlyList<SheetRef> GetSheets() => _sheets;
+        public IReadOnlyList<SheetRef> GetSheets() => _sheets.AsReadOnly();
 
         public Stream GetSheetStream(int index)
         {

--- a/ooxml/XSSF/EventUserModel/XSSFSheetXMLHandler.cs
+++ b/ooxml/XSSF/EventUserModel/XSSFSheetXMLHandler.cs
@@ -1,0 +1,276 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Xml;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.Model;
+using NPOI.XSSF.UserModel;
+
+namespace NPOI.XSSF.EventUserModel
+{
+    /// <summary>
+    /// Incrementally parses a single worksheet's XML, emitting SheetContentsHandler
+    /// callbacks one row at a time. Faithful in shape to Apache POI's
+    /// XSSFSheetXMLHandler, driven by a pull XmlReader so an IEnumerable consumer
+    /// can advance row-by-row.
+    /// </summary>
+    public class XSSFSheetXMLHandler : IDisposable
+    {
+        private readonly XmlReader _reader;
+        private readonly StylesTable _styles;
+        private readonly ReadOnlySharedStringsTable _strings;
+        private readonly SheetContentsHandler _handler;
+        private readonly DataFormatter _formatter = new DataFormatter();
+
+        public XSSFSheetXMLHandler(Stream sheetStream, StylesTable styles,
+            ReadOnlySharedStringsTable strings, SheetContentsHandler handler)
+        {
+            _styles = styles;
+            _strings = strings;
+            _handler = handler;
+            _reader = XmlReader.Create(sheetStream, new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit });
+        }
+
+        /// <summary>Parse forward until one full &lt;row&gt; is emitted. False at end of sheet.</summary>
+        public bool ParseNextRow()
+        {
+            while (_reader.Read())
+            {
+                if (_reader.NodeType == XmlNodeType.Element && _reader.LocalName == "row")
+                {
+                    int rowNum = ParseInt(_reader.GetAttribute("r"), 1) - 1;
+                    bool empty = _reader.IsEmptyElement;
+                    _handler.StartRow(rowNum);
+                    if (!empty)
+                    {
+                        ReadRowCells(rowNum);
+                    }
+                    _handler.EndRow(rowNum);
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void ReadRowCells(int rowNum)
+        {
+            int depth = _reader.Depth;
+            while (_reader.Read())
+            {
+                if (_reader.NodeType == XmlNodeType.EndElement && _reader.LocalName == "row" && _reader.Depth == depth)
+                {
+                    return;
+                }
+                if (_reader.NodeType == XmlNodeType.Element && _reader.LocalName == "c")
+                {
+                    ReadCell();
+                }
+            }
+        }
+
+        private void ReadCell()
+        {
+            string cellRef = _reader.GetAttribute("r") ?? string.Empty;
+            string type = _reader.GetAttribute("t");
+            string styleIdx = _reader.GetAttribute("s");
+            bool cellIsEmpty = _reader.IsEmptyElement;
+
+            string vText = null;
+            string inlineText = null;
+            bool isFormula = false;
+
+            if (!cellIsEmpty)
+            {
+                int depth = _reader.Depth;
+                while (_reader.Read())
+                {
+                    if (_reader.NodeType == XmlNodeType.EndElement && _reader.LocalName == "c" && _reader.Depth == depth)
+                    {
+                        break;
+                    }
+                    if (_reader.NodeType == XmlNodeType.Element && _reader.LocalName == "v")
+                    {
+                        vText = ReadElementText();
+                    }
+                    else if (_reader.NodeType == XmlNodeType.Element && _reader.LocalName == "f")
+                    {
+                        isFormula = true;
+                        // Formula text itself is unused (cached <v> supplies Value/Text), but the
+                        // element must still be consumed so the outer loop doesn't miss its end tag.
+                        if (!_reader.IsEmptyElement)
+                        {
+                            ReadElementText();
+                        }
+                    }
+                    else if (_reader.NodeType == XmlNodeType.Element && _reader.LocalName == "is")
+                    {
+                        inlineText = ReadInlineString();
+                    }
+                }
+            }
+
+            EmitCell(cellRef, type, styleIdx, vText, inlineText, isFormula);
+        }
+
+        /// <summary>
+        /// Reads the text content of a simple leaf element (e.g. &lt;v&gt;123&lt;/v&gt;) whose
+        /// current node is its StartElement, WITHOUT using XmlReader.ReadElementContentAsString().
+        /// That method advances the reader past the element's EndElement onto the *next* node,
+        /// but every caller here sits inside a while(_reader.Read()) loop that scopes its own
+        /// boundary by depth/name on EndElement; skipping straight past the EndElement would
+        /// make the loop's next Read() consume (and lose) whatever node follows - typically the
+        /// enclosing element's own EndElement (e.g. &lt;/c&gt;), which would then overrun into the
+        /// next sibling and corrupt cell/row boundaries. Instead: manually step onto the Text
+        /// node and read its Value, leaving the EndElement for the caller's loop to consume on
+        /// its own next iteration (matches neither the "v"/"f" start branch nor the boundary
+        /// check, so it's a harmless no-op there). Mirrors the fix already applied in
+        /// ReadOnlySharedStringsTable.ReadFrom for the identical class of bug.
+        /// </summary>
+        private string ReadElementText()
+        {
+            if (_reader.IsEmptyElement)
+            {
+                return string.Empty;
+            }
+            int depth = _reader.Depth;
+            var sb = new StringBuilder();
+            while (_reader.Read())
+            {
+                if (_reader.NodeType == XmlNodeType.EndElement && _reader.Depth == depth)
+                {
+                    break;
+                }
+                if (_reader.NodeType == XmlNodeType.Text || _reader.NodeType == XmlNodeType.SignificantWhitespace)
+                {
+                    sb.Append(_reader.Value);
+                }
+            }
+            return sb.ToString();
+        }
+
+        private string ReadInlineString()
+        {
+            if (_reader.IsEmptyElement)
+            {
+                return string.Empty;
+            }
+            var sb = new StringBuilder();
+            int depth = _reader.Depth;
+            while (_reader.Read())
+            {
+                if (_reader.NodeType == XmlNodeType.EndElement && _reader.LocalName == "is" && _reader.Depth == depth)
+                {
+                    break;
+                }
+                if (_reader.NodeType == XmlNodeType.Element && _reader.LocalName == "t")
+                {
+                    sb.Append(ReadElementText());
+                }
+            }
+            return sb.ToString();
+        }
+
+        private void EmitCell(string cellRef, string type, string styleIdx, string vText, string inlineText, bool isFormula)
+        {
+            object raw;
+            string text;
+            StreamValueKind kind;
+
+            switch (type)
+            {
+                case "s":
+                    raw = text = !string.IsNullOrEmpty(vText)
+                        ? _strings.GetEntryAt(int.Parse(vText, CultureInfo.InvariantCulture))
+                        : string.Empty;
+                    kind = StreamValueKind.String;
+                    break;
+                case "inlineStr":
+                    raw = text = inlineText ?? string.Empty;
+                    kind = StreamValueKind.String;
+                    break;
+                case "str":
+                    raw = text = vText ?? string.Empty;
+                    kind = StreamValueKind.Formula;
+                    break;
+                case "b":
+                    bool b = vText == "1";
+                    raw = b;
+                    text = b ? "TRUE" : "FALSE";
+                    kind = StreamValueKind.Boolean;
+                    break;
+                case "e":
+                    raw = text = vText ?? string.Empty;
+                    kind = StreamValueKind.Error;
+                    break;
+                default: // "n" or absent
+                    if (string.IsNullOrEmpty(vText))
+                    {
+                        raw = null;
+                        text = string.Empty;
+                        kind = StreamValueKind.Blank;
+                    }
+                    else
+                    {
+                        double d = double.Parse(vText, CultureInfo.InvariantCulture);
+                        int numFmtId = 0;
+                        string fmtString = null;
+                        if (!string.IsNullOrEmpty(styleIdx))
+                        {
+                            XSSFCellStyle cs = _styles.GetStyleAt(int.Parse(styleIdx, CultureInfo.InvariantCulture));
+                            if (cs != null)
+                            {
+                                numFmtId = cs.DataFormat;
+                                fmtString = cs.GetDataFormatString();
+                            }
+                        }
+                        if (DateUtil.IsADateFormat(numFmtId, fmtString))
+                        {
+                            raw = DateUtil.GetJavaDate(d);
+                            kind = StreamValueKind.Date;
+                        }
+                        else
+                        {
+                            raw = d;
+                            kind = StreamValueKind.Number;
+                        }
+                        text = _formatter.FormatRawCellContents(d, numFmtId, fmtString);
+                    }
+                    break;
+            }
+
+            // Presence of <f> marks the cell as a formula regardless of the resolved value's
+            // own type - including when the cached <v> is a self-closing/empty element (NPOI
+            // itself writes unevaluated formulas as e.g. "<f>B1*2</f><v/>", which would otherwise
+            // resolve to Blank above and hide the fact that this is a formula cell).
+            if (isFormula && kind != StreamValueKind.Formula)
+            {
+                kind = StreamValueKind.Formula;
+            }
+
+            _handler.Cell(cellRef, text, raw, kind);
+        }
+
+        private static int ParseInt(string s, int fallback)
+            => int.TryParse(s, NumberStyles.Integer, CultureInfo.InvariantCulture, out int v) ? v : fallback;
+
+        public void Dispose() => _reader?.Dispose();
+    }
+}

--- a/ooxml/XSSF/EventUserModel/XSSFSheetXMLHandler.cs
+++ b/ooxml/XSSF/EventUserModel/XSSFSheetXMLHandler.cs
@@ -241,6 +241,16 @@ namespace NPOI.XSSF.EventUserModel
                                 fmtString = cs.GetDataFormatString();
                             }
                         }
+                        // A numeric cell with no style (or a style whose format string can't be
+                        // resolved) uses Excel's implicit "General" format. DataFormatter.GetFormat
+                        // calls formatStrIn.IndexOf(';') with no null guard (unlike its ICell
+                        // overload), so a null fmtString here would NRE - this is spec-valid and
+                        // common: SXSSF and other minimal writers emit unstyled numeric cells like
+                        // <c r="A1"><v>123</v></c> with no "s" attribute at all.
+                        if (string.IsNullOrEmpty(fmtString))
+                        {
+                            fmtString = "General";
+                        }
                         if (DateUtil.IsADateFormat(numFmtId, fmtString))
                         {
                             raw = DateUtil.GetJavaDate(d);

--- a/ooxml/XSSF/Model/ReadOnlySharedStringsTable.cs
+++ b/ooxml/XSSF/Model/ReadOnlySharedStringsTable.cs
@@ -71,7 +71,20 @@ namespace NPOI.XSSF.Model
                 {
                     if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "si")
                     {
-                        current = new StringBuilder();
+                        if (reader.IsEmptyElement)
+                        {
+                            // A self-closing <si/> is schema-valid and represents an empty shared
+                            // string. XmlReader never raises a separate EndElement for it, so if we
+                            // set `current` here we would never see the matching "si end" branch
+                            // below to flush it - the next <si> would just overwrite `current`,
+                            // silently dropping this entry and shifting every later index by one.
+                            // Record it immediately instead, and leave `current` untouched (null).
+                            _strings.Add(string.Empty);
+                        }
+                        else
+                        {
+                            current = new StringBuilder();
+                        }
                     }
                     else if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "t" && current != null)
                     {
@@ -84,7 +97,9 @@ namespace NPOI.XSSF.Model
                             // let the outer loop consume </t> on its next iteration (harmless, matches
                             // neither the "si" nor "t"-start branch).
                             reader.Read();
-                            if (reader.NodeType == XmlNodeType.Text || reader.NodeType == XmlNodeType.SignificantWhitespace)
+                            if (reader.NodeType == XmlNodeType.Text
+                                || reader.NodeType == XmlNodeType.SignificantWhitespace
+                                || reader.NodeType == XmlNodeType.CDATA)
                             {
                                 current.Append(reader.Value);
                             }

--- a/ooxml/XSSF/Model/ReadOnlySharedStringsTable.cs
+++ b/ooxml/XSSF/Model/ReadOnlySharedStringsTable.cs
@@ -1,0 +1,102 @@
+/* ====================================================================
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for Additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+==================================================================== */
+
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Xml;
+using NPOI.OpenXml4Net.OPC;
+using NPOI.XSSF.UserModel;
+
+namespace NPOI.XSSF.Model
+{
+    /// <summary>
+    /// Forward-only, read-only view of a workbook's shared strings table.
+    /// Reads sharedStrings.xml once into memory (plain text per &lt;si&gt;),
+    /// without building the rich-text DOM. Memory scales with unique-string
+    /// count, not row count.
+    /// </summary>
+    public class ReadOnlySharedStringsTable
+    {
+        private readonly List<string> _strings = new List<string>();
+
+        public ReadOnlySharedStringsTable(OPCPackage pkg)
+        {
+            List<PackagePart> parts = pkg.GetPartsByContentType(XSSFRelation.SHARED_STRINGS.ContentType);
+            if (parts.Count == 0)
+            {
+                return;
+            }
+            using (Stream stream = parts[0].GetInputStream())
+            {
+                ReadFrom(stream);
+            }
+        }
+
+        public ReadOnlySharedStringsTable(Stream sharedStringsXml)
+        {
+            ReadFrom(sharedStringsXml);
+        }
+
+        public int Count => _strings.Count;
+
+        public string GetEntryAt(int index) => _strings[index];
+
+        private void ReadFrom(Stream stream)
+        {
+            XmlReaderSettings settings = new XmlReaderSettings
+            {
+                IgnoreComments = true,
+                IgnoreProcessingInstructions = true,
+                DtdProcessing = DtdProcessing.Prohibit,
+            };
+            using (XmlReader reader = XmlReader.Create(stream, settings))
+            {
+                StringBuilder current = null;
+                while (reader.Read())
+                {
+                    if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "si")
+                    {
+                        current = new StringBuilder();
+                    }
+                    else if (reader.NodeType == XmlNodeType.Element && reader.LocalName == "t" && current != null)
+                    {
+                        if (!reader.IsEmptyElement)
+                        {
+                            // Deliberately not using ReadElementContentAsString() here: it leaves the
+                            // reader positioned on the node *after* </t>, and the outer while(reader.Read())
+                            // would then skip that node (typically the enclosing </si>), corrupting the
+                            // si-boundary tracking below. Advance onto the text node manually instead and
+                            // let the outer loop consume </t> on its next iteration (harmless, matches
+                            // neither the "si" nor "t"-start branch).
+                            reader.Read();
+                            if (reader.NodeType == XmlNodeType.Text || reader.NodeType == XmlNodeType.SignificantWhitespace)
+                            {
+                                current.Append(reader.Value);
+                            }
+                        }
+                    }
+                    else if (reader.NodeType == XmlNodeType.EndElement && reader.LocalName == "si" && current != null)
+                    {
+                        _strings.Add(current.ToString());
+                        current = null;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/testcases/ooxml/XSSF/EventUserModel/TestXSSFReader.cs
+++ b/testcases/ooxml/XSSF/EventUserModel/TestXSSFReader.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using NPOI.OpenXml4Net.OPC;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.EventUserModel;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+
+namespace NPOI.XSSF.EventUserModel
+{
+    [TestFixture]
+    public class TestXSSFReader
+    {
+        private static string WriteTwoSheetBook()
+        {
+            string path = Path.Combine(Path.GetTempPath(), "xl263_reader_" + System.Guid.NewGuid().ToString("N") + ".xlsx");
+            IWorkbook wb = new XSSFWorkbook();
+            wb.CreateSheet("First").CreateRow(0).CreateCell(0).SetCellValue("hello");
+            wb.CreateSheet("Second").CreateRow(0).CreateCell(0).SetCellValue(42.0);
+            using (FileStream fs = File.Create(path)) { wb.Write(fs); }
+            wb.Close();
+            return path;
+        }
+
+        [Test]
+        public void EnumeratesSheetsInOrder()
+        {
+            string path = WriteTwoSheetBook();
+            OPCPackage pkg = OPCPackage.Open(path);
+            try
+            {
+                XSSFReader reader = new XSSFReader(pkg);
+                var sheets = reader.GetSheets();
+                Assert.AreEqual(2, sheets.Count);
+                Assert.AreEqual("First", sheets[0].Name);
+                Assert.AreEqual("Second", sheets[1].Name);
+                Assert.IsNotNull(reader.GetStylesTable());
+                Assert.IsNotNull(reader.GetSharedStringsTable());
+            }
+            finally
+            {
+                pkg.Close();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public void GetSheetStreamByNameMatchesIndex()
+        {
+            string path = WriteTwoSheetBook();
+            OPCPackage pkg = OPCPackage.Open(path);
+            try
+            {
+                XSSFReader reader = new XSSFReader(pkg);
+                using (Stream byName = reader.GetSheetStream("Second"))
+                using (Stream byIndex = reader.GetSheetStream(1))
+                {
+                    Assert.IsNotNull(byName);
+                    Assert.IsNotNull(byIndex);
+                }
+                Assert.Throws<System.ArgumentException>(() => reader.GetSheetStream("Missing"));
+                Assert.Throws<System.ArgumentException>(() => reader.GetSheetStream(9));
+            }
+            finally
+            {
+                pkg.Close();
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/testcases/ooxml/XSSF/EventUserModel/TestXSSFSheetXMLHandler.cs
+++ b/testcases/ooxml/XSSF/EventUserModel/TestXSSFSheetXMLHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using NPOI.OpenXml4Net.OPC;
 using NPOI.SS.UserModel;
 using NPOI.XSSF.EventUserModel;
@@ -114,6 +115,43 @@ namespace NPOI.XSSF.EventUserModel
                 File.Delete(path);
             }
             finally { System.Threading.Thread.CurrentThread.CurrentCulture = prev; }
+        }
+
+        [Test]
+        public void ParsesInlineStringFormulaStringErrorAndBlankCells()
+        {
+            // Fed as a literal worksheet-XML fragment (bypassing XSSFWorkbook, which always
+            // prefers shared strings) so the t="inlineStr" / t="str" / t="e" / self-closing-cell
+            // paths in ReadInlineString/EmitCell get real coverage.
+            const string xml =
+                "<?xml version=\"1.0\"?>" +
+                "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">" +
+                "<sheetData>" +
+                "<row r=\"1\">" +
+                "<c r=\"A1\" t=\"inlineStr\"><is><t>Hello</t></is></c>" +
+                "<c r=\"B1\" t=\"inlineStr\"><is><r><t>Wor</t></r><r><t>ld</t></r></is></c>" +
+                "<c r=\"C1\" t=\"str\"><f>A1</f><v>calc</v></c>" +
+                "<c r=\"D1\" t=\"e\"><v>#DIV/0!</v></c>" +
+                "<c r=\"E1\"/>" +
+                "</row>" +
+                "</sheetData>" +
+                "</worksheet>";
+
+            var styles = new StylesTable();
+            var strings = new ReadOnlySharedStringsTable(new MemoryStream(Encoding.UTF8.GetBytes(
+                "<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"/>")));
+            var handler = new Collector();
+            using (Stream s = new MemoryStream(Encoding.UTF8.GetBytes(xml)))
+            {
+                var h = new XSSFSheetXMLHandler(s, styles, strings, handler);
+                while (h.ParseNextRow()) { }
+            }
+
+            CollectionAssert.Contains(handler.Events, "C:A1:String:Hello:Hello");
+            CollectionAssert.Contains(handler.Events, "C:B1:String:World:World");
+            Assert.IsTrue(handler.Events.Exists(e => e.StartsWith("C:C1:Formula:calc")));
+            Assert.IsTrue(handler.Events.Exists(e => e.StartsWith("C:D1:Error:#DIV/0!")));
+            Assert.IsTrue(handler.Events.Exists(e => e.StartsWith("C:E1:Blank:")));
         }
     }
 }

--- a/testcases/ooxml/XSSF/EventUserModel/TestXSSFSheetXMLHandler.cs
+++ b/testcases/ooxml/XSSF/EventUserModel/TestXSSFSheetXMLHandler.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using NPOI.OpenXml4Net.OPC;
+using NPOI.SS.UserModel;
+using NPOI.XSSF.EventUserModel;
+using NPOI.XSSF.Model;
+using NPOI.XSSF.UserModel;
+using NUnit.Framework;
+
+namespace NPOI.XSSF.EventUserModel
+{
+    [TestFixture]
+    public class TestXSSFSheetXMLHandler
+    {
+        private sealed class Collector : SheetContentsHandler
+        {
+            public readonly List<string> Events = new List<string>();
+            public void StartRow(int r) => Events.Add($"SR:{r}");
+            public void EndRow(int r) => Events.Add($"ER:{r}");
+            public void Cell(string reference, string text, object raw, StreamValueKind kind)
+            {
+                // Format raw explicitly with InvariantCulture: boxed as `object`, raw's default
+                // ToString() (via plain string interpolation) dispatches to e.g. double.ToString()
+                // with no provider, which resolves to the ambient thread culture and would render
+                // "12.5" as "12,5" under de-DE/fr-FR - masking the exact culture-invariance this
+                // test exists to check on the handler's own parsing, not on this test helper.
+                string rawText = raw is IFormattable f ? f.ToString(null, CultureInfo.InvariantCulture) : raw?.ToString() ?? "";
+                Events.Add($"C:{reference}:{kind}:{rawText}:{text}");
+            }
+            public void HeaderFooter(string t, bool h, string n) { }
+        }
+
+        [Test]
+        public void ParsesNumbersStringsBoolsDatesFormulas()
+        {
+            // Author a workbook with known cells, then stream-read its first sheet.
+            string path = Path.Combine(Path.GetTempPath(), "xl263_h_" + Guid.NewGuid().ToString("N") + ".xlsx");
+            IWorkbook wb = new XSSFWorkbook();
+            ISheet sh = wb.CreateSheet("S");
+            IRow row = sh.CreateRow(0);
+            row.CreateCell(0).SetCellValue("text");
+            row.CreateCell(1).SetCellValue(12.5);
+            row.CreateCell(2).SetCellValue(true);
+            ICell date = row.CreateCell(3);
+            ICellStyle ds = wb.CreateCellStyle();
+            ds.DataFormat = wb.CreateDataFormat().GetFormat("yyyy-mm-dd");
+            date.CellStyle = ds;
+            date.SetCellValue(new DateTime(2026, 8, 6));
+            ICell formula = row.CreateCell(4);
+            formula.CellFormula = "B1*2";
+            using (FileStream fs = File.Create(path)) { wb.Write(fs); }
+            wb.Close();
+
+            var events = new List<string>();
+            OPCPackage pkg = OPCPackage.Open(path);
+            try
+            {
+                XSSFReader reader = new XSSFReader(pkg);
+                var handler = new Collector();
+                using (Stream s = reader.GetSheetStream(0))
+                {
+                    var h = new XSSFSheetXMLHandler(s, reader.GetStylesTable(), reader.GetSharedStringsTable(), handler);
+                    while (h.ParseNextRow()) { }
+                }
+                events = handler.Events;
+            }
+            finally
+            {
+                pkg.Close();
+            }
+            File.Delete(path);
+
+            Assert.Contains("SR:0", events);
+            Assert.Contains("ER:0", events);
+            CollectionAssert.Contains(events, "C:A1:String:text:text");
+            Assert.IsTrue(events.Exists(e => e.StartsWith("C:B1:Number:12.5")));
+            Assert.IsTrue(events.Exists(e => e.StartsWith("C:C1:Boolean:")));
+            Assert.IsTrue(events.Exists(e => e.StartsWith("C:D1:Date:")));
+            Assert.IsTrue(events.Exists(e => e.StartsWith("C:E1:Formula:")));
+        }
+
+        [TestCase("de-DE")]
+        [TestCase("fr-FR")]
+        public void RawNumbersAreCultureInvariant(string culture)
+        {
+            var prev = System.Threading.Thread.CurrentThread.CurrentCulture;
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo(culture);
+            try
+            {
+                string path = Path.Combine(Path.GetTempPath(), "xl263_c_" + Guid.NewGuid().ToString("N") + ".xlsx");
+                IWorkbook wb = new XSSFWorkbook();
+                wb.CreateSheet("S").CreateRow(0).CreateCell(0).SetCellValue(12.5);
+                using (FileStream fs = File.Create(path)) { wb.Write(fs); }
+                wb.Close();
+
+                OPCPackage pkg = OPCPackage.Open(path);
+                try
+                {
+                    XSSFReader reader = new XSSFReader(pkg);
+                    var handler = new Collector();
+                    using (Stream s = reader.GetSheetStream(0))
+                    {
+                        var h = new XSSFSheetXMLHandler(s, reader.GetStylesTable(), reader.GetSharedStringsTable(), handler);
+                        while (h.ParseNextRow()) { }
+                    }
+                    Assert.IsTrue(handler.Events.Exists(e => e.StartsWith("C:A1:Number:12.5")));
+                }
+                finally
+                {
+                    pkg.Close();
+                }
+                File.Delete(path);
+            }
+            finally { System.Threading.Thread.CurrentThread.CurrentCulture = prev; }
+        }
+    }
+}

--- a/testcases/ooxml/XSSF/EventUserModel/TestXSSFSheetXMLHandler.cs
+++ b/testcases/ooxml/XSSF/EventUserModel/TestXSSFSheetXMLHandler.cs
@@ -153,5 +153,40 @@ namespace NPOI.XSSF.EventUserModel
             Assert.IsTrue(handler.Events.Exists(e => e.StartsWith("C:D1:Error:#DIV/0!")));
             Assert.IsTrue(handler.Events.Exists(e => e.StartsWith("C:E1:Blank:")));
         }
+
+        [Test]
+        public void ParsesUnstyledNumericCellsWithoutThrowing()
+        {
+            // Spec-valid and common: minimal writers (SXSSF and others) emit numeric cells
+            // with no "s" (style) attribute at all, e.g. <c r="A1"><v>123</v></c>. An unstyled
+            // numeric cell uses Excel's implicit "General" format; EmitCell must not pass a
+            // null format string down to DataFormatter.FormatRawCellContents in that case.
+            const string xml =
+                "<?xml version=\"1.0\"?>" +
+                "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">" +
+                "<sheetData>" +
+                "<row r=\"1\">" +
+                "<c r=\"A1\"><v>123</v></c>" +
+                "<c r=\"B1\" t=\"n\"><v>45.6</v></c>" +
+                "</row>" +
+                "</sheetData>" +
+                "</worksheet>";
+
+            var styles = new StylesTable();
+            var strings = new ReadOnlySharedStringsTable(new MemoryStream(Encoding.UTF8.GetBytes(
+                "<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"/>")));
+            var handler = new Collector();
+            using (Stream s = new MemoryStream(Encoding.UTF8.GetBytes(xml)))
+            {
+                var h = new XSSFSheetXMLHandler(s, styles, strings, handler);
+                Assert.DoesNotThrow(() => { while (h.ParseNextRow()) { } });
+            }
+
+            Assert.IsTrue(handler.Events.Exists(e => e.StartsWith("C:A1:Number:123")));
+            Assert.IsTrue(handler.Events.Exists(e => e.StartsWith("C:B1:Number:45.6")));
+            // The formatted text must be present and non-empty, not just the raw value.
+            string a1 = handler.Events.Find(e => e.StartsWith("C:A1:Number:"));
+            Assert.IsFalse(string.IsNullOrEmpty(a1.Split(':')[4]));
+        }
     }
 }

--- a/testcases/ooxml/XSSF/Model/TestReadOnlySharedStringsTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestReadOnlySharedStringsTable.cs
@@ -58,6 +58,41 @@ namespace NPOI.XSSF.Model
         }
 
         [Test]
+        public void SelfClosingSiAtFirstAndLastPositionKeepIndices()
+        {
+            var sst = new ReadOnlySharedStringsTable(Xml(
+                "<si/><si><t>Mid</t></si><si/>"));
+
+            Assert.AreEqual(3, sst.Count);
+            Assert.AreEqual(string.Empty, sst.GetEntryAt(0));
+            Assert.AreEqual("Mid", sst.GetEntryAt(1));
+            Assert.AreEqual(string.Empty, sst.GetEntryAt(2));
+        }
+
+        [Test]
+        public void ConsecutiveSelfClosingSiEachYieldEmptyString()
+        {
+            var sst = new ReadOnlySharedStringsTable(Xml(
+                "<si><t>Before</t></si><si/><si/><si><t>After</t></si>"));
+
+            Assert.AreEqual(4, sst.Count);
+            Assert.AreEqual("Before", sst.GetEntryAt(0));
+            Assert.AreEqual(string.Empty, sst.GetEntryAt(1));
+            Assert.AreEqual(string.Empty, sst.GetEntryAt(2));
+            Assert.AreEqual("After", sst.GetEntryAt(3));
+        }
+
+        [Test]
+        public void CDataInsideRichRunIsPreserved()
+        {
+            var sst = new ReadOnlySharedStringsTable(Xml(
+                "<si><r><t>Ga</t></r><r><t><![CDATA[mma]]></t></r></si>"));
+
+            Assert.AreEqual(1, sst.Count);
+            Assert.AreEqual("Gamma", sst.GetEntryAt(0));
+        }
+
+        [Test]
         public void ReadsSharedStringsFromOpcPackage()
         {
             FileInfo file = TempFile.CreateTempFile("TestReadOnlySharedStringsTable-", ".xlsx");

--- a/testcases/ooxml/XSSF/Model/TestReadOnlySharedStringsTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestReadOnlySharedStringsTable.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Text;
+using NPOI.XSSF.Model;
+using NUnit.Framework;
+
+namespace NPOI.XSSF.Model
+{
+    [TestFixture]
+    public class TestReadOnlySharedStringsTable
+    {
+        private static Stream Xml(string body) =>
+            new MemoryStream(Encoding.UTF8.GetBytes(
+                "<?xml version=\"1.0\"?><sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"3\" uniqueCount=\"3\">"
+                + body + "</sst>"));
+
+        [Test]
+        public void ReadsPlainAndRichStrings()
+        {
+            var sst = new ReadOnlySharedStringsTable(Xml(
+                "<si><t>Alpha</t></si>" +
+                "<si><t xml:space=\"preserve\"> Beta </t></si>" +
+                "<si><r><t>Ga</t></r><r><t>mma</t></r></si>"));
+
+            Assert.AreEqual(3, sst.Count);
+            Assert.AreEqual("Alpha", sst.GetEntryAt(0));
+            Assert.AreEqual(" Beta ", sst.GetEntryAt(1));
+            Assert.AreEqual("Gamma", sst.GetEntryAt(2));
+        }
+
+        [Test]
+        public void EmptyTableHasZeroCount()
+        {
+            var sst = new ReadOnlySharedStringsTable(Xml(string.Empty));
+            Assert.AreEqual(0, sst.Count);
+        }
+    }
+}

--- a/testcases/ooxml/XSSF/Model/TestReadOnlySharedStringsTable.cs
+++ b/testcases/ooxml/XSSF/Model/TestReadOnlySharedStringsTable.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Text;
-using NPOI.XSSF.Model;
+using NPOI.OpenXml4Net.OPC;
+using NPOI.Util;
+using NPOI.XSSF.UserModel;
 using NUnit.Framework;
 
 namespace NPOI.XSSF.Model
@@ -32,6 +34,69 @@ namespace NPOI.XSSF.Model
         {
             var sst = new ReadOnlySharedStringsTable(Xml(string.Empty));
             Assert.AreEqual(0, sst.Count);
+        }
+
+        [Test]
+        public void SelfClosingSiYieldsEmptyString()
+        {
+            var sst = new ReadOnlySharedStringsTable(Xml(
+                "<si><t>First</t></si><si/><si><t>Third</t></si>"));
+
+            Assert.AreEqual(3, sst.Count);
+            Assert.AreEqual("First", sst.GetEntryAt(0));
+            Assert.AreEqual(string.Empty, sst.GetEntryAt(1));
+            Assert.AreEqual("Third", sst.GetEntryAt(2));
+        }
+
+        [Test]
+        public void CDataInsideTIsPreserved()
+        {
+            var sst = new ReadOnlySharedStringsTable(Xml("<si><t><![CDATA[Hello]]></t></si>"));
+
+            Assert.AreEqual(1, sst.Count);
+            Assert.AreEqual("Hello", sst.GetEntryAt(0));
+        }
+
+        [Test]
+        public void ReadsSharedStringsFromOpcPackage()
+        {
+            FileInfo file = TempFile.CreateTempFile("TestReadOnlySharedStringsTable-", ".xlsx");
+            try
+            {
+                using (var wb = new XSSFWorkbook())
+                {
+                    var sheet = wb.CreateSheet();
+                    var row = sheet.CreateRow(0);
+                    row.CreateCell(0).SetCellValue("Delta");
+                    row.CreateCell(1).SetCellValue("Epsilon");
+
+                    using (var fs = new FileStream(file.FullName, FileMode.Create, FileAccess.Write))
+                    {
+                        wb.Write(fs);
+                    }
+                }
+
+                OPCPackage pkg = OPCPackage.Open(file.FullName, PackageAccess.READ);
+                try
+                {
+                    var sst = new ReadOnlySharedStringsTable(pkg);
+
+                    Assert.AreEqual(2, sst.Count);
+                    Assert.AreEqual("Delta", sst.GetEntryAt(0));
+                    Assert.AreEqual("Epsilon", sst.GetEntryAt(1));
+                }
+                finally
+                {
+                    pkg.Close();
+                }
+            }
+            finally
+            {
+                if (file.Exists)
+                {
+                    file.Delete();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This pull request adds a forward-only, low-memory streaming reader for XLSX worksheets, modelled on Apache POI's event based `XSSFReader` and `XSSFSheetXMLHandler`. It lets a consumer read very large workbooks one row at a time without building the full `XSSFWorkbook` object graph in memory. This is the NPOI side of Iron Software ticket XL-263, and it is consumed by a companion IronXL pull request that exposes it as `WorkBook.StreamRows(...)`.

All new types are additive. No existing NPOI read or write behaviour is changed by the new classes.

## What this adds

- `NPOI.XSSF.Model.ReadOnlySharedStringsTable`: a read-only, low-memory shared strings table that reads `sharedStrings.xml` with an `XmlReader` instead of loading the DOM. It handles plain strings, rich text runs, self-closing entries, and CDATA content.
- `NPOI.XSSF.EventUserModel.XSSFReader`: opens an `OPCPackage` and exposes the workbook parts (styles table and shared strings table) and the worksheet streams in document order, selectable by index or by name.
- `NPOI.XSSF.EventUserModel.SheetContentsHandler`: the callback interface for a single-sheet streaming parse, together with a `StreamValueKind` classification of each cell value.
- `NPOI.XSSF.EventUserModel.XSSFSheetXMLHandler`: an incremental worksheet parser driven by `XmlReader` that emits one row at a time through the handler, resolving numbers, shared and inline strings, booleans, dates, formulas, and errors.

## Bug fixes included

Two pre-existing defects were found while testing the streaming path and are fixed here.

1. `DataFormatter.FormatRawCellContents` parsed numeric text using the ambient thread culture. Under some cultures this silently corrupted the value, and under others it threw a `FormatException`. The text produced by `NumberToTextConverter` is always invariant format, so the parse is now explicitly invariant. Behaviour on invariant and en-US threads is unchanged.
2. A numeric cell with no style attribute produced a null format string, which caused a `NullReferenceException` in the formatting path. Unstyled numeric cells are common and spec valid, so the streaming handler now falls back to the General format for them.

## Testing

New unit tests cover the shared strings reader, the package and sheet iterator, and the sheet parser. Cases include non-US cultures (de-DE and fr-FR), inline and rich text strings, self-closing entries, CDATA, blank cells, error and formula cells, and unstyled numeric cells. Tests were run on net6.0 using the multi-target test project.

## Compatibility

The new code targets the same frameworks as the rest of NPOI (net472, netstandard2.0, netstandard2.1, and net6.0) and avoids APIs that are not available on all of them.

## Related

Companion IronXL pull request: iron-software/IronXL#288

Iron Software ticket: XL-263
